### PR TITLE
유저가 자주 사용하는 태그 등록 및 태그 사용 시 카운팅

### DIFF
--- a/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
+++ b/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 @Getter
 public enum ExceptionCodeConst {
 
-    //SAMPLE CONST
-    NOT_FOUND_USER(404, "NOT_FOUND_USER", "유저가 존재하지 않습니다.");
+    NOT_FOUND_USER(404, "NOT_FOUND_USER", "유저가 존재하지 않습니다."),
+    ALREADY_EXIST_TAG(409, "ALREADY_EXIST_TAG", "이미 존재하는 태그입니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/project/linkarchive/backend/advice/success/SuccessCodeConst.java
+++ b/src/main/java/project/linkarchive/backend/advice/success/SuccessCodeConst.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum SuccessCodeConst {
 
-    URL_CREATE(201, "URL_CREATE", "url 이 생성되었습니다.");
+    URL_CREATE(201, "URL_CREATE", "url 이 생성되었습니다."),
+    USER_TAG_CREATE(201, "USER_TAG_CREATE", "유저가 자주 사용하는 태그가 생성되었습니다.");
 
     private int status;
     private String code;

--- a/src/main/java/project/linkarchive/backend/hashtag/controller/HashTagApiController.java
+++ b/src/main/java/project/linkarchive/backend/hashtag/controller/HashTagApiController.java
@@ -1,4 +1,29 @@
 package project.linkarchive.backend.hashtag.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import project.linkarchive.backend.advice.success.SuccessResponse;
+import project.linkarchive.backend.hashtag.request.TagCreateRequest;
+import project.linkarchive.backend.hashtag.service.HashTagApiService;
+
+import static project.linkarchive.backend.advice.success.SuccessCodeConst.USER_TAG_CREATE;
+
+@RestController
 public class HashTagApiController {
+
+    private final HashTagApiService hashTagApiService;
+
+    public HashTagApiController(HashTagApiService hashTagApiService) {
+        this.hashTagApiService = hashTagApiService;
+    }
+
+    @PostMapping("/tag")
+    public ResponseEntity<SuccessResponse> create(@RequestBody TagCreateRequest request) {
+        hashTagApiService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new SuccessResponse(USER_TAG_CREATE));
+    }
+
 }

--- a/src/main/java/project/linkarchive/backend/hashtag/domain/HashTag.java
+++ b/src/main/java/project/linkarchive/backend/hashtag/domain/HashTag.java
@@ -31,11 +31,9 @@ public class HashTag extends CreatedEntity {
     private List<UrlHashTag> urlHashTagList = new ArrayList<>();
 
     @Builder
-    public HashTag(Long id, String tag, List<UserHashTag> userHashTags, List<UrlHashTag> urlHashTagList) {
+    public HashTag(Long id, String tag) {
         this.id = id;
         this.tag = tag;
-        this.userHashTags = userHashTags;
-        this.urlHashTagList = urlHashTagList;
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/hashtag/request/TagCreateRequest.java
+++ b/src/main/java/project/linkarchive/backend/hashtag/request/TagCreateRequest.java
@@ -1,0 +1,10 @@
+package project.linkarchive.backend.hashtag.request;
+
+import lombok.Getter;
+
+@Getter
+public class TagCreateRequest {
+
+    private String tag;
+
+}

--- a/src/main/java/project/linkarchive/backend/hashtag/service/HashTagApiService.java
+++ b/src/main/java/project/linkarchive/backend/hashtag/service/HashTagApiService.java
@@ -34,6 +34,7 @@ public class HashTagApiService {
                     throw new BusinessException(ALREADY_EXIST_TAG);
                 }, () -> {
                     UserHashTag getHashTag = UserHashTag.builder()
+                            .userHashTagCount(0L)
                             .hashTag(hashTag)
                             .build();
                     userHashTagRepository.save(getHashTag);

--- a/src/main/java/project/linkarchive/backend/hashtag/service/HashTagApiService.java
+++ b/src/main/java/project/linkarchive/backend/hashtag/service/HashTagApiService.java
@@ -1,4 +1,43 @@
 package project.linkarchive.backend.hashtag.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.linkarchive.backend.advice.exception.BusinessException;
+import project.linkarchive.backend.hashtag.domain.HashTag;
+import project.linkarchive.backend.hashtag.repository.HashTagRepository;
+import project.linkarchive.backend.hashtag.request.TagCreateRequest;
+import project.linkarchive.backend.user.domain.UserHashTag;
+import project.linkarchive.backend.user.repository.UserHashTagRepository;
+
+import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.ALREADY_EXIST_TAG;
+
+@Service
+@Transactional
 public class HashTagApiService {
+
+    private final HashTagRepository hashTagRepository;
+    private final UserHashTagRepository userHashTagRepository;
+
+    public HashTagApiService(HashTagRepository hashTagRepository, UserHashTagRepository userHashTagRepository) {
+        this.hashTagRepository = hashTagRepository;
+        this.userHashTagRepository = userHashTagRepository;
+    }
+
+    public void create(TagCreateRequest request) {
+        HashTag hashTag = hashTagRepository.findByTag(request.getTag())
+                .orElseGet(() -> HashTag.builder()
+                        .tag(request.getTag())
+                        .build());
+
+        userHashTagRepository.findByHashTagId(hashTag.getId())
+                .ifPresentOrElse(userHashTag -> {
+                    throw new BusinessException(ALREADY_EXIST_TAG);
+                }, () -> {
+                    UserHashTag getHashTag = UserHashTag.builder()
+                            .hashTag(hashTag)
+                            .build();
+                    userHashTagRepository.save(getHashTag);
+                });
+    }
+
 }

--- a/src/main/java/project/linkarchive/backend/url/service/UrlApiService.java
+++ b/src/main/java/project/linkarchive/backend/url/service/UrlApiService.java
@@ -7,32 +7,38 @@ import project.linkarchive.backend.hashtag.repository.HashTagRepository;
 import project.linkarchive.backend.url.domain.Url;
 import project.linkarchive.backend.url.domain.UrlHashTag;
 import project.linkarchive.backend.url.repository.UrlHashTagRepository;
-import project.linkarchive.backend.url.repository.UrlRepository;
 import project.linkarchive.backend.url.request.UrlCreateRequest;
+import project.linkarchive.backend.user.repository.UserHashTagRepository;
 
 @Service
 @Transactional
 public class UrlApiService {
 
-    private final UrlRepository urlRepository;
     private final HashTagRepository hashTagRepository;
     private final UrlHashTagRepository urlHashTagRepository;
+    private final UserHashTagRepository userHashTagRepository;
 
-    public UrlApiService(UrlRepository urlRepository, HashTagRepository hashTagRepository, UrlHashTagRepository urlHashTagRepository) {
-        this.urlRepository = urlRepository;
+    public UrlApiService(HashTagRepository hashTagRepository, UrlHashTagRepository urlHashTagRepository, UserHashTagRepository userHashTagRepository) {
         this.hashTagRepository = hashTagRepository;
         this.urlHashTagRepository = urlHashTagRepository;
+        this.userHashTagRepository = userHashTagRepository;
     }
 
     public void create(UrlCreateRequest urlCreateRequest) {
         Url url = Url.of(urlCreateRequest);
         urlCreateRequest.getTag().stream()
-                .map(hashtag -> {
-                    HashTag hashTag = hashTagRepository.findByTag(hashtag)
-                            .orElseGet(() -> HashTag.builder().tag(hashtag).build());
-                    return UrlHashTag.builder().url(url).hashTag(hashTag).build();
-                })
-                .forEach(urlHashTagRepository::save);
+                .map(hashtag -> hashTagRepository.findByTag(hashtag)
+                        .orElseGet(() -> HashTag.builder()
+                                .tag(hashtag)
+                                .build()))
+                .forEach(hashTag -> {
+                    userHashTagRepository.findByHashTagId(hashTag.getId())
+                            .ifPresent(tag -> tag.increaseUserHashTagCount(tag.getUserHashTagCount()));
+                    urlHashTagRepository.save(UrlHashTag.builder()
+                            .url(url)
+                            .hashTag(hashTag)
+                            .build());
+                });
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/user/domain/UserHashTag.java
+++ b/src/main/java/project/linkarchive/backend/user/domain/UserHashTag.java
@@ -19,6 +19,8 @@ public class UserHashTag extends CreatedEntity {
     @Column(name = "user_hashtag_id")
     private Long id;
 
+    private Long userHashTagCount;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -28,10 +30,15 @@ public class UserHashTag extends CreatedEntity {
     private HashTag hashTag;
 
     @Builder
-    public UserHashTag(Long id, User user, HashTag hashTag) {
+    public UserHashTag(Long id, Long userHashTagCount, User user, HashTag hashTag) {
         this.id = id;
+        this.userHashTagCount = userHashTagCount;
         this.user = user;
         this.hashTag = hashTag;
+    }
+
+    public void increaseUserHashTagCount(Long count) {
+        this.userHashTagCount = ++count;
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/user/domain/UserHashTag.java
+++ b/src/main/java/project/linkarchive/backend/user/domain/UserHashTag.java
@@ -23,7 +23,7 @@ public class UserHashTag extends CreatedEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "hashtag_id")
     private HashTag hashTag;
 

--- a/src/main/java/project/linkarchive/backend/user/repository/UserHashTagRepository.java
+++ b/src/main/java/project/linkarchive/backend/user/repository/UserHashTagRepository.java
@@ -1,0 +1,12 @@
+package project.linkarchive.backend.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import project.linkarchive.backend.user.domain.UserHashTag;
+
+import java.util.Optional;
+
+public interface UserHashTagRepository extends JpaRepository<UserHashTag, Long> {
+
+    Optional<UserHashTag> findByHashTagId(Long hashTagId);
+
+}


### PR DESCRIPTION
## 개요
1. 유저가 자주 사용하는 태그를 등록하는 기능을 만들었어요.
2. 링크 생성 시 자둥으로 유저가 자주 사용하는 해시태그 카운팅 기능을 만들었어요.

## 📌 관련 이슈

## ✨ 과제 내용
- [ ] 유저가 자주 사용하는 태그를 등록하는 기능이에요.
- [ ] 함수형 프로그그래밍 방식으로 구현했어요.
- [ ] 링크 생성 시 생성하는 태그가 유저가 자주 사용하는 태그에 등록되어 있는 태그와 일치하면,
- [ ] 자동으로 카운팅되는 기능을 만들었어요.
- [ ] 마찬가지로, 함수형 프로그래밍 방식으로 구현했어요.