### PR TITLE
url 생성을 위한 메타데이터 불러오기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	implementation 'org.jsoup:jsoup:1.14.3'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/project/linkarchive/backend/url/controller/UrlApiController.java
+++ b/src/main/java/project/linkarchive/backend/url/controller/UrlApiController.java
@@ -1,14 +1,20 @@
 package project.linkarchive.backend.url.controller;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import project.linkarchive.backend.advice.success.SuccessCodeConst;
 import project.linkarchive.backend.advice.success.SuccessResponse;
 import project.linkarchive.backend.url.request.UrlCreateRequest;
+import project.linkarchive.backend.url.response.UrlMetaDataResponse;
 import project.linkarchive.backend.url.service.UrlApiService;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 @RestController
 public class UrlApiController {
@@ -23,6 +29,46 @@ public class UrlApiController {
     public ResponseEntity<SuccessResponse> create(@RequestBody UrlCreateRequest request) {
         urlApiService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new SuccessResponse(SuccessCodeConst.URL_CREATE));
+    }
+
+    @GetMapping("/url/metadata")
+    public ResponseEntity<UrlMetaDataResponse> getUrlMetaData(@RequestParam(value = "url") String url) {
+        URL urlObject;
+        try {
+            urlObject = new URL(url);
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        HttpURLConnection connection;
+        try {
+            connection = (HttpURLConnection) urlObject.openConnection();
+            connection.setRequestMethod("GET");
+            connection.connect();
+            int responseCode = connection.getResponseCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        Document document;
+        try {
+            document = Jsoup.connect(url).get();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        String title = document.select("meta[property=og:title]").attr("content");
+        String description = document.select("meta[property=og:description]").attr("content");
+        String thumbnail = document.select("meta[property=og:image]").attr("content");
+
+        UrlMetaDataResponse urlMetaDataResponse = new UrlMetaDataResponse(title, description, thumbnail);
+        return ResponseEntity.ok(urlMetaDataResponse);
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/url/controller/UrlApiController.java
+++ b/src/main/java/project/linkarchive/backend/url/controller/UrlApiController.java
@@ -1,20 +1,14 @@
 package project.linkarchive.backend.url.controller;
 
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 import project.linkarchive.backend.advice.success.SuccessCodeConst;
 import project.linkarchive.backend.advice.success.SuccessResponse;
 import project.linkarchive.backend.url.request.UrlCreateRequest;
-import project.linkarchive.backend.url.response.UrlMetaDataResponse;
 import project.linkarchive.backend.url.service.UrlApiService;
-
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
 
 @RestController
 public class UrlApiController {
@@ -29,46 +23,6 @@ public class UrlApiController {
     public ResponseEntity<SuccessResponse> create(@RequestBody UrlCreateRequest request) {
         urlApiService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new SuccessResponse(SuccessCodeConst.URL_CREATE));
-    }
-
-    @GetMapping("/url/metadata")
-    public ResponseEntity<UrlMetaDataResponse> getUrlMetaData(@RequestParam(value = "url") String url) {
-        URL urlObject;
-        try {
-            urlObject = new URL(url);
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-        }
-
-        HttpURLConnection connection;
-        try {
-            connection = (HttpURLConnection) urlObject.openConnection();
-            connection.setRequestMethod("GET");
-            connection.connect();
-            int responseCode = connection.getResponseCode();
-            if (responseCode != HttpURLConnection.HTTP_OK) {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        }
-
-        Document document;
-        try {
-            document = Jsoup.connect(url).get();
-        } catch (IOException e) {
-            e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        }
-
-        String title = document.select("meta[property=og:title]").attr("content");
-        String description = document.select("meta[property=og:description]").attr("content");
-        String thumbnail = document.select("meta[property=og:image]").attr("content");
-
-        UrlMetaDataResponse urlMetaDataResponse = new UrlMetaDataResponse(title, description, thumbnail);
-        return ResponseEntity.ok(urlMetaDataResponse);
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/url/controller/UrlQueryController.java
+++ b/src/main/java/project/linkarchive/backend/url/controller/UrlQueryController.java
@@ -1,4 +1,60 @@
 package project.linkarchive.backend.url.controller;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import project.linkarchive.backend.url.response.UrlMetaDataResponse;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+@RestController
 public class UrlQueryController {
+
+    @GetMapping("/url/metadata")
+    public ResponseEntity<UrlMetaDataResponse> getUrlMetaData(@RequestParam(value = "url") String url) {
+        URL urlObject;
+        try {
+            urlObject = new URL(url);
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        HttpURLConnection connection;
+        try {
+            connection = (HttpURLConnection) urlObject.openConnection();
+            connection.setRequestMethod("GET");
+            connection.connect();
+            int responseCode = connection.getResponseCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        Document document;
+        try {
+            document = Jsoup.connect(url).get();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        String title = document.select("meta[property=og:title]").attr("content");
+        String description = document.select("meta[property=og:description]").attr("content");
+        String thumbnail = document.select("meta[property=og:image]").attr("content");
+
+        UrlMetaDataResponse urlMetaDataResponse = new UrlMetaDataResponse(title, description, thumbnail);
+        return ResponseEntity.ok(urlMetaDataResponse);
+    }
+
 }

--- a/src/main/java/project/linkarchive/backend/url/domain/Url.java
+++ b/src/main/java/project/linkarchive/backend/url/domain/Url.java
@@ -23,9 +23,13 @@ public class Url extends TimeEntity {
     @Column(name = "url_id")
     private Long id;
 
-    private String thumbnail;
-    private String title;
     private String url;
+    private String title;
+
+    @Column(length = 500)
+    private String description;
+
+    private String thumbnail;
     private Long bookMarkCount;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -39,22 +43,22 @@ public class Url extends TimeEntity {
     private List<BookMark> bookMarkList = new ArrayList<>();
 
     @Builder
-    public Url(Long id, String thumbnail, String title, String url, Long bookMarkCount, User user, List<UrlHashTag> urlHashTagList, List<BookMark> bookMarkList) {
+    public Url(Long id, String url, String title, String description, String thumbnail, Long bookMarkCount, User user) {
         this.id = id;
-        this.thumbnail = thumbnail;
-        this.title = title;
         this.url = url;
+        this.title = title;
+        this.description = description;
+        this.thumbnail = thumbnail;
         this.bookMarkCount = bookMarkCount;
         this.user = user;
-        this.urlHashTagList = urlHashTagList;
-        this.bookMarkList = bookMarkList;
     }
 
     public static Url of(UrlCreateRequest request) {
         return Url.builder()
-                .thumbnail(request.getThumbnail())
-                .title(request.getTitle())
                 .url(request.getUrl())
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .thumbnail(request.getThumbnail())
                 .bookMarkCount(0L)
                 .build();
     }

--- a/src/main/java/project/linkarchive/backend/url/request/UrlCreateRequest.java
+++ b/src/main/java/project/linkarchive/backend/url/request/UrlCreateRequest.java
@@ -10,15 +10,17 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UrlCreateRequest {
 
-    private String thumbnail;
-    private String title;
     private String url;
+    private String title;
+    private String description;
+    private String thumbnail;
     private List<String> tag;
 
-    public UrlCreateRequest(String thumbnail, String title, String url, List<String> tag) {
-        this.thumbnail = thumbnail;
-        this.title = title;
+    public UrlCreateRequest(String url, String title, String description, String thumbnail, List<String> tag) {
         this.url = url;
+        this.title = title;
+        this.description = description;
+        this.thumbnail = thumbnail;
         this.tag = tag;
     }
 

--- a/src/main/java/project/linkarchive/backend/url/response/UrlMetaDataResponse.java
+++ b/src/main/java/project/linkarchive/backend/url/response/UrlMetaDataResponse.java
@@ -1,0 +1,18 @@
+package project.linkarchive.backend.url.response;
+
+import lombok.Getter;
+
+@Getter
+public class UrlMetaDataResponse {
+
+    private String title;
+    private String description;
+    private String thumbnail;
+
+    public UrlMetaDataResponse(String title, String description, String thumbnail) {
+        this.title = title;
+        this.description = description;
+        this.thumbnail = thumbnail;
+    }
+
+}


### PR DESCRIPTION
## 개요
url 생성을 하기 위한 메타 데이터를 불러오는 기능을 만들었어요.

## 📌 관련 이슈
#6 

## ✨ 과제 내용
- [ ] url를 request로 받아서 메타 데이터를 불러오는 기능을 만들었어요.
- [ ] url을 생성할 때 meta data를 받아서 request요청을 받게끔 수정했어요.
- [ ] url에 description 정보를 담아주기 위해 엔티티에 추가를 했어요.
- [ ] 메타 데이터를 불러오기 위해서 jsoup 라이브러리를 사용했어요. 
- [ ] jsoup 라이브러리를 사용 안해도 돼지만 굳이 학습할 필요성을 못느껴서 trade-off 했어요.