### PR TITLE
링크 둘러보기에서 유저 정보 Response 추가

### DIFF
--- a/src/main/java/project/linkarchive/backend/url/repository/UrlRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/url/repository/UrlRepositoryImpl.java
@@ -4,8 +4,8 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import project.linkarchive.backend.url.response.linkList.QUserExcludedLinkListDetailResponse;
 import project.linkarchive.backend.url.response.linkList.UserExcludedLinkListDetailResponse;
-import project.linkarchive.backend.url.response.linkList.QLinkListDetailResponse;
 import project.linkarchive.backend.url.response.userLinkList.QUserLinkListDetailResponse;
 import project.linkarchive.backend.url.response.userLinkList.UserLinkListDetailResponse;
 
@@ -24,7 +24,7 @@ public class UrlRepositoryImpl {
     }
 
     public List<UserLinkListDetailResponse> getUserLinkList(Pageable pageable, Long lastUrlId) {
-        List<UserLinkListDetailResponse> content = queryFactory
+        return queryFactory
                 .select(new QUserLinkListDetailResponse(
                         url.id,
                         url.link,
@@ -40,13 +40,14 @@ public class UrlRepositoryImpl {
                 .limit(pageable.getPageSize())
                 .orderBy(url.id.desc())
                 .fetch();
-
-        return content;
     }
 
     public List<UserExcludedLinkListDetailResponse> getLinkList(Pageable pageable, Long lastUrlId) {
-        List<UserExcludedLinkListDetailResponse> content = queryFactory
-                .select(new QLinkListDetailResponse(
+        return queryFactory
+                .select(new QUserExcludedLinkListDetailResponse(
+                        url.user.id,
+                        url.user.name,
+                        url.user.userProfileImage.imagePath,
                         url.id,
                         url.link,
                         url.title,
@@ -55,14 +56,14 @@ public class UrlRepositoryImpl {
                         url.bookMarkCount
                 ))
                 .from(url)
+                .leftJoin(url.user)
+                .leftJoin(url.user.userProfileImage)
                 .where(
                         ltUrlId(lastUrlId)
                 )
                 .limit(pageable.getPageSize())
                 .orderBy(url.id.desc())
                 .fetch();
-
-        return content;
     }
 
     private BooleanExpression ltUrlId(Long lastUrlId) {

--- a/src/main/java/project/linkarchive/backend/url/response/linkList/UserExcludedLinkListDetailResponse.java
+++ b/src/main/java/project/linkarchive/backend/url/response/linkList/UserExcludedLinkListDetailResponse.java
@@ -6,6 +6,9 @@ import lombok.Getter;
 @Getter
 public class UserExcludedLinkListDetailResponse {
 
+    private Long userId;
+    private String name;
+    private String profileImage;
     private Long urlId;
     private String link;
     private String title;
@@ -14,7 +17,10 @@ public class UserExcludedLinkListDetailResponse {
     private Long bookMarkCount;
 
     @QueryProjection
-    public UserExcludedLinkListDetailResponse(Long urlId, String link, String title, String description, String thumbnail, Long bookMarkCount) {
+    public UserExcludedLinkListDetailResponse(Long userId, String name, String profileImage, Long urlId, String link, String title, String description, String thumbnail, Long bookMarkCount) {
+        this.userId = userId;
+        this.name = name;
+        this.profileImage = profileImage;
         this.urlId = urlId;
         this.link = link;
         this.title = title;

--- a/src/main/java/project/linkarchive/backend/url/response/linkList/UserExcludedLinkTagListDetailResponse.java
+++ b/src/main/java/project/linkarchive/backend/url/response/linkList/UserExcludedLinkTagListDetailResponse.java
@@ -7,6 +7,9 @@ import java.util.List;
 @Getter
 public class UserExcludedLinkTagListDetailResponse {
 
+    private Long userId;
+    private String name;
+    private String profileImage;
     private Long urlId;
     private String link;
     private String title;
@@ -15,7 +18,10 @@ public class UserExcludedLinkTagListDetailResponse {
     private Long bookMarkCount;
     private List<UserExcludedTagListDetailResponse> linkTagList;
 
-    public UserExcludedLinkTagListDetailResponse(Long urlId, String link, String title, String description, String thumbnail, Long bookMarkCount, List<UserExcludedTagListDetailResponse> linkTagList) {
+    public UserExcludedLinkTagListDetailResponse(Long userId, String name, String profileImage, Long urlId, String link, String title, String description, String thumbnail, Long bookMarkCount, List<UserExcludedTagListDetailResponse> linkTagList) {
+        this.userId = userId;
+        this.name = name;
+        this.profileImage = profileImage;
         this.urlId = urlId;
         this.link = link;
         this.title = title;

--- a/src/main/java/project/linkarchive/backend/url/service/UrlQueryService.java
+++ b/src/main/java/project/linkarchive/backend/url/service/UrlQueryService.java
@@ -79,6 +79,9 @@ public class UrlQueryService {
                                     h.getHashTag().getTag()))
                             .collect(Collectors.toList());
                     return new UserExcludedLinkTagListDetailResponse(
+                            l.getUserId(),
+                            l.getName(),
+                            l.getProfileImage(),
                             l.getUrlId(),
                             l.getLink(),
                             l.getTitle(),


### PR DESCRIPTION
## 개요
링크 둘러보기에서 유저에 관한 정보를 담을 Response를 추가했어요.

## 📌 관련 이슈
`관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요`

## ✨ 과제 내용
`과제에 대한 설명을 적어주세요`  
- [ ] 각 링크를 작성한 사용자에 대한 정보를 담을 Response를 만들었어요.
- [ ] 우선, 널 값으로 반한해요.
