### PR TITLE
북마크 링크 리스트 조회하는 기능

### DIFF
--- a/src/main/java/project/linkarchive/backend/bookmark/controller/BookMarkQueryController.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/controller/BookMarkQueryController.java
@@ -1,4 +1,29 @@
 package project.linkarchive.backend.bookmark.controller;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import project.linkarchive.backend.bookmark.response.UserMarkedLinkListResponse;
+import project.linkarchive.backend.bookmark.service.BookMarkQueryService;
+
+@RestController
 public class BookMarkQueryController {
+
+    private final BookMarkQueryService bookMarkQueryService;
+
+    public BookMarkQueryController(BookMarkQueryService bookMarkQueryService) {
+        this.bookMarkQueryService = bookMarkQueryService;
+    }
+
+    @GetMapping("/links/mark")
+    public ResponseEntity<UserMarkedLinkListResponse> getMarkLinkList(@PageableDefault(direction = Sort.Direction.DESC) Pageable pageable,
+                                                                      @RequestParam(value = "urlId", required = false) Long lastUrlId) {
+        UserMarkedLinkListResponse userMarkedLinkListResponse = bookMarkQueryService.getMarkLinkList(pageable, lastUrlId);
+        return ResponseEntity.ok(userMarkedLinkListResponse);
+    }
+
 }

--- a/src/main/java/project/linkarchive/backend/bookmark/repository/BookMarkRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/repository/BookMarkRepositoryImpl.java
@@ -1,0 +1,49 @@
+package project.linkarchive.backend.bookmark.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import project.linkarchive.backend.bookmark.response.QUserMarkedLinkListDetailResponse;
+import project.linkarchive.backend.bookmark.response.UserMarkedLinkListDetailResponse;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static project.linkarchive.backend.bookmark.domain.QBookMark.bookMark;
+
+@Repository
+public class BookMarkRepositoryImpl {
+
+    private final JPAQueryFactory queryFactory;
+
+    public BookMarkRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    public List<UserMarkedLinkListDetailResponse> getMarkLinkList(Pageable pageable, Long lastMarkId) {
+        return queryFactory
+                .select(new QUserMarkedLinkListDetailResponse(
+                        bookMark.id,
+                        bookMark.url.id,
+                        bookMark.url.link,
+                        bookMark.url.title,
+                        bookMark.url.description,
+                        bookMark.url.thumbnail,
+                        bookMark.url.bookMarkCount
+                ))
+                .from(bookMark)
+                .leftJoin(bookMark.url)
+                .where(
+                        ltMarkId(lastMarkId)
+                )
+                .limit(pageable.getPageSize())
+                .orderBy(bookMark.id.desc(), bookMark.url.bookMarkCount.desc())
+                .fetch();
+    }
+
+    private BooleanExpression ltMarkId(Long lastMarkId) {
+        return lastMarkId != null ? bookMark.url.id.lt(lastMarkId) : null;
+    }
+
+}

--- a/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkedLinkListDetailResponse.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkedLinkListDetailResponse.java
@@ -1,0 +1,28 @@
+package project.linkarchive.backend.bookmark.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class UserMarkedLinkListDetailResponse {
+
+    private Long markId;
+    private Long urlId;
+    private String link;
+    private String title;
+    private String description;
+    private String thumbnail;
+    private Long markCount;
+
+    @QueryProjection
+    public UserMarkedLinkListDetailResponse(Long markId, Long urlId, String link, String title, String description, String thumbnail, Long markCount) {
+        this.markId = markId;
+        this.urlId = urlId;
+        this.link = link;
+        this.title = title;
+        this.description = description;
+        this.thumbnail = thumbnail;
+        this.markCount = markCount;
+    }
+
+}

--- a/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkedLinkListResponse.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkedLinkListResponse.java
@@ -1,0 +1,19 @@
+package project.linkarchive.backend.bookmark.response;
+
+import lombok.Getter;
+import project.linkarchive.backend.user.response.userLinkList.UserTagList30Response;
+
+import java.util.List;
+
+@Getter
+public class UserMarkedLinkListResponse {
+
+    private List<UserTagList30Response> userTagList;
+    List<UserMarkedLinkTagListDetailResponse> markLinkList;
+
+    public UserMarkedLinkListResponse(List<UserTagList30Response> userTagList, List<UserMarkedLinkTagListDetailResponse> markLinkList) {
+        this.userTagList = userTagList;
+        this.markLinkList = markLinkList;
+    }
+
+}

--- a/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkedLinkTagListDetailResponse.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkedLinkTagListDetailResponse.java
@@ -1,0 +1,31 @@
+package project.linkarchive.backend.bookmark.response;
+
+import lombok.Getter;
+import project.linkarchive.backend.hashtag.response.TagListDetailResponse;
+
+import java.util.List;
+
+@Getter
+public class UserMarkedLinkTagListDetailResponse {
+
+    private Long markId;
+    private Long urlId;
+    private String link;
+    private String title;
+    private String description;
+    private String thumbnail;
+    private Long markCount;
+    private List<TagListDetailResponse> markLinkTagList;
+
+    public UserMarkedLinkTagListDetailResponse(Long markId, Long urlId, String link, String title, String description, String thumbnail, Long markCount, List<TagListDetailResponse> markLinkTagList) {
+        this.markId = markId;
+        this.urlId = urlId;
+        this.link = link;
+        this.title = title;
+        this.description = description;
+        this.thumbnail = thumbnail;
+        this.markCount = markCount;
+        this.markLinkTagList = markLinkTagList;
+    }
+    
+}

--- a/src/main/java/project/linkarchive/backend/bookmark/service/BookMarkQueryService.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/service/BookMarkQueryService.java
@@ -1,4 +1,68 @@
 package project.linkarchive.backend.bookmark.service;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.linkarchive.backend.bookmark.repository.BookMarkRepositoryImpl;
+import project.linkarchive.backend.bookmark.response.UserMarkedLinkListDetailResponse;
+import project.linkarchive.backend.bookmark.response.UserMarkedLinkListResponse;
+import project.linkarchive.backend.bookmark.response.UserMarkedLinkTagListDetailResponse;
+import project.linkarchive.backend.hashtag.repository.HashTagRepository;
+import project.linkarchive.backend.hashtag.response.TagListDetailResponse;
+import project.linkarchive.backend.url.domain.UrlHashTag;
+import project.linkarchive.backend.url.repository.UrlHashTagRepository;
+import project.linkarchive.backend.user.domain.UserHashTag;
+import project.linkarchive.backend.user.repository.UserHashTagRepository;
+import project.linkarchive.backend.user.response.userLinkList.UserTagList30Response;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
 public class BookMarkQueryService {
+
+    private final HashTagRepository hashTagRepository;
+    private final UserHashTagRepository userHashTagRepository;
+    private final BookMarkRepositoryImpl bookMarkRepositoryImpl;
+    private final UrlHashTagRepository urlHashTagRepository;
+
+    public BookMarkQueryService(HashTagRepository hashTagRepository, UserHashTagRepository userHashTagRepository, BookMarkRepositoryImpl bookMarkRepositoryImpl, UrlHashTagRepository urlHashTagRepository) {
+        this.hashTagRepository = hashTagRepository;
+        this.userHashTagRepository = userHashTagRepository;
+        this.bookMarkRepositoryImpl = bookMarkRepositoryImpl;
+        this.urlHashTagRepository = urlHashTagRepository;
+    }
+
+    public UserMarkedLinkListResponse getMarkLinkList(Pageable pageable, Long lastUrlId) {
+        //FIXME user가 자주 사용하는 해시태그 30개 조회로 리팩토링 필요. user 정보 없어서 조회하는걸로 대체했어요
+        List<UserHashTag> userHashTagList = userHashTagRepository.findAll();
+        List<UserTagList30Response> userTagList30ResponseList = userHashTagList.stream()
+                .map(h -> new UserTagList30Response(h.getHashTag().getId(), h.getHashTag().getTag())).collect(Collectors.toList());
+
+        //FIXME 기능에 초점을 둬서 쿼리 성능이 좋지 않아요.
+        List<UserMarkedLinkListDetailResponse> userMarkedLinkListDetailResponseList = bookMarkRepositoryImpl.getMarkLinkList(pageable, lastUrlId);
+        List<UserMarkedLinkTagListDetailResponse> userMarkedLinkTagListDetailResponseList = userMarkedLinkListDetailResponseList.stream()
+                .map(m -> {
+                    List<UrlHashTag> urlHashTagList = urlHashTagRepository.findByUrlId(m.getUrlId());
+                    List<TagListDetailResponse> tagListResponseListDetailList = urlHashTagList.stream()
+                            .map(h -> new TagListDetailResponse(
+                                    h.getHashTag().getId(),
+                                    h.getHashTag().getTag())).collect(Collectors.toList());
+
+                    return new UserMarkedLinkTagListDetailResponse(
+                            m.getMarkId(),
+                            m.getUrlId(),
+                            m.getLink(),
+                            m.getTitle(),
+                            m.getDescription(),
+                            m.getThumbnail(),
+                            m.getMarkCount(),
+                            tagListResponseListDetailList
+                    );
+                }).collect(Collectors.toList());
+
+        return new UserMarkedLinkListResponse(userTagList30ResponseList, userMarkedLinkTagListDetailResponseList);
+    }
+
 }

--- a/src/main/java/project/linkarchive/backend/hashtag/response/TagListDetailResponse.java
+++ b/src/main/java/project/linkarchive/backend/hashtag/response/TagListDetailResponse.java
@@ -1,0 +1,16 @@
+package project.linkarchive.backend.hashtag.response;
+
+import lombok.Getter;
+
+@Getter
+public class TagListDetailResponse {
+
+    private Long tagId;
+    private String tagName;
+
+    public TagListDetailResponse(Long tagId, String tagName) {
+        this.tagId = tagId;
+        this.tagName = tagName;
+    }
+
+}

--- a/src/main/java/project/linkarchive/backend/url/domain/Url.java
+++ b/src/main/java/project/linkarchive/backend/url/domain/Url.java
@@ -59,7 +59,7 @@ public class Url extends TimeEntity {
                 .title(request.getTitle())
                 .description(request.getDescription())
                 .thumbnail(request.getThumbnail())
-                .bookMarkCount(0L)
+                .bookMarkCount(7L)
                 .build();
     }
     


### PR DESCRIPTION
## 개요
로그인한 유저의 북마크 링크 리스트를 조회하는 기능을 만들었어요.

## 📌 관련 이슈
#25 

## ✨ 과제 내용
- [ ] 북마크 링크 리스트를 조회하는 기능이에요.
- [ ] 유저 정보가 없어서 해시태그 리스트를 전부 조회하는 기능으로 대채했어요.
- [ ] 쿼리 성능에 대한 향상이 필요해요.
