### PR TITLE
유저가 자주 사용하는 해시태그 생성 시 User 정보 값

### DIFF
--- a/src/main/java/project/linkarchive/backend/hashtag/controller/HashTagApiController.java
+++ b/src/main/java/project/linkarchive/backend/hashtag/controller/HashTagApiController.java
@@ -2,16 +2,19 @@ package project.linkarchive.backend.hashtag.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import project.linkarchive.backend.advice.success.SuccessResponse;
 import project.linkarchive.backend.hashtag.request.TagCreateRequest;
 import project.linkarchive.backend.hashtag.service.HashTagApiService;
+import project.linkarchive.backend.security.AuthInfo;
 
 import static project.linkarchive.backend.advice.success.SuccessCodeConst.USER_TAG_CREATE;
 
 @RestController
+@PreAuthorize("isAuthenticated()")
 public class HashTagApiController {
 
     private final HashTagApiService hashTagApiService;
@@ -21,8 +24,8 @@ public class HashTagApiController {
     }
 
     @PostMapping("/tag")
-    public ResponseEntity<SuccessResponse> create(@RequestBody TagCreateRequest request) {
-        hashTagApiService.create(request);
+    public ResponseEntity<SuccessResponse> create(@RequestBody TagCreateRequest request, AuthInfo authInfo) {
+        hashTagApiService.create(request, authInfo.getId());
         return ResponseEntity.status(HttpStatus.CREATED).body(new SuccessResponse(USER_TAG_CREATE));
     }
 

--- a/src/main/java/project/linkarchive/backend/hashtag/domain/HashTag.java
+++ b/src/main/java/project/linkarchive/backend/hashtag/domain/HashTag.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.linkarchive.backend.advice.entityBase.CreatedEntity;
+import project.linkarchive.backend.hashtag.request.TagCreateRequest;
 import project.linkarchive.backend.url.domain.UrlHashTag;
 import project.linkarchive.backend.user.domain.UserHashTag;
 
@@ -31,9 +32,14 @@ public class HashTag extends CreatedEntity {
     private List<UrlHashTag> urlHashTagList = new ArrayList<>();
 
     @Builder
-    public HashTag(Long id, String tag) {
-        this.id = id;
+    public HashTag(String tag) {
         this.tag = tag;
+    }
+
+    public static HashTag of(TagCreateRequest request) {
+        return HashTag.builder()
+                .tag(request.getTag())
+                .build();
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/hashtag/service/HashTagApiService.java
+++ b/src/main/java/project/linkarchive/backend/hashtag/service/HashTagApiService.java
@@ -6,39 +6,48 @@ import project.linkarchive.backend.advice.exception.BusinessException;
 import project.linkarchive.backend.hashtag.domain.HashTag;
 import project.linkarchive.backend.hashtag.repository.HashTagRepository;
 import project.linkarchive.backend.hashtag.request.TagCreateRequest;
+import project.linkarchive.backend.user.domain.User;
 import project.linkarchive.backend.user.domain.UserHashTag;
 import project.linkarchive.backend.user.repository.UserHashTagRepository;
+import project.linkarchive.backend.user.repository.UserRepository;
 
 import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.ALREADY_EXIST_TAG;
+import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.NOT_FOUND_USER;
 
 @Service
 @Transactional
 public class HashTagApiService {
 
+    private final UserRepository userRepository;
     private final HashTagRepository hashTagRepository;
     private final UserHashTagRepository userHashTagRepository;
 
-    public HashTagApiService(HashTagRepository hashTagRepository, UserHashTagRepository userHashTagRepository) {
+    public HashTagApiService(UserRepository userRepository, HashTagRepository hashTagRepository, UserHashTagRepository userHashTagRepository) {
+        this.userRepository = userRepository;
         this.hashTagRepository = hashTagRepository;
         this.userHashTagRepository = userHashTagRepository;
     }
 
-    public void create(TagCreateRequest request) {
+    public void create(TagCreateRequest request, Long userId) {
+        User user = findUserById(userId);
+
         HashTag hashTag = hashTagRepository.findByTag(request.getTag())
-                .orElseGet(() -> HashTag.builder()
-                        .tag(request.getTag())
-                        .build());
+                .orElseGet(() -> HashTag.of(request));
 
         userHashTagRepository.findByHashTagId(hashTag.getId())
                 .ifPresentOrElse(userHashTag -> {
-                    throw new BusinessException(ALREADY_EXIST_TAG);
-                }, () -> {
-                    UserHashTag getHashTag = UserHashTag.builder()
-                            .userHashTagCount(0L)
-                            .hashTag(hashTag)
-                            .build();
-                    userHashTagRepository.save(getHashTag);
-                });
+                            throw new BusinessException(ALREADY_EXIST_TAG);
+                        },
+                        () -> {
+                            UserHashTag getHashTag = UserHashTag.of(user, hashTag);
+                            userHashTagRepository.save(getHashTag);
+                        });
     }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(NOT_FOUND_USER));
+    }
+
 
 }

--- a/src/main/java/project/linkarchive/backend/user/domain/UserHashTag.java
+++ b/src/main/java/project/linkarchive/backend/user/domain/UserHashTag.java
@@ -30,11 +30,18 @@ public class UserHashTag extends CreatedEntity {
     private HashTag hashTag;
 
     @Builder
-    public UserHashTag(Long id, Long userHashTagCount, User user, HashTag hashTag) {
-        this.id = id;
+    public UserHashTag(Long userHashTagCount, User user, HashTag hashTag) {
         this.userHashTagCount = userHashTagCount;
         this.user = user;
         this.hashTag = hashTag;
+    }
+
+    public static UserHashTag of(User user, HashTag hashTag) {
+        return UserHashTag.builder()
+                .userHashTagCount(0L)
+                .user(user)
+                .hashTag(hashTag)
+                .build();
     }
 
     public void increaseUserHashTagCount(Long count) {


### PR DESCRIPTION
## 개요
유저가 자주 사용하는 해시태그를 등록하는 기능에 로그인한 유저의 정보를 포함하는 기능을 리팩토링 했어요.

## 📌 관련 이슈
close #5 

## ✨ 과제 내용
- [ ] 유저가 자주 사용하는 해시태그를 등록할 때 유저 정보를 포함하는 기능을 추가했어요.
