### PR TITLE
유저 프로필 수정하는 API

### DIFF
--- a/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
+++ b/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
@@ -21,7 +21,8 @@ public enum ExceptionCodeConst {
     ALREADY_EXIST_NICKNAME(409, "ALREADY_EXIST_NICKNAME", "이미 존재하는 닉네임 입니다."),
 
     LENGTH_REQUIRED_TAG(416, "LENGTH_REQUIRED_TAG", "Tag의 길이를 2글자 이상 8글자 이하로 작성해주세요."),
-    LENGTH_REQUIRED_NICKNAME(416, "LENGTH_REQUIRED_TAG", "닉네임의 길이를 2글자 이상 16글자 이하로 작성해주세요."),
+    LENGTH_REQUIRED_NICKNAME(416, "LENGTH_REQUIRED_NICKNAME", "닉네임의 길이를 2글자 이상 16글자 이하로 작성해주세요."),
+    LENGTH_REQUIRED_INTRODUCE(416, "LENGTH_REQUIRED_INTRODUCE", "자기소개는 20글자 이하로 작성해주세요."),
 
     EXCEEDED_TAG_LIMIT_10(416, "EXCEEDED_TAG_LIMIT", "태그의 개수가 10개를 초과할 수 없습니다."),
     EXCEEDED_TAG_SIZE(416, "EXCEEDED_TAG_SIZE", "해시태그 조회 갯수를 초과했습니다.");

--- a/src/main/java/project/linkarchive/backend/advice/success/SuccessCodeConst.java
+++ b/src/main/java/project/linkarchive/backend/advice/success/SuccessCodeConst.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum SuccessCodeConst {
 
     LOGIN_SUCCESS(200, "LOGIN", "회원가입에 성공했습니다."),
+    UPDATE_USER_PROFILE(200, "UPDATE_USER_PROFILE", "유저의 프로필이 수정되었습니다."),
     UPDATE_PROFILE_IMAGE(200, "UPDATE_PROFILE_IMAGE", "프로필 이미지가 수정되었습니다."),
     UPDATE_NICKNAME(200, "UPDATE_NICKNAME", "닉네임이 수정되었습니다."),
     BOOK_MARK_CANCEL(200, "BOOK_MARK_CANCEL", "북마크가 취소되었습니다."),

--- a/src/main/java/project/linkarchive/backend/auth/service/OAuthService.java
+++ b/src/main/java/project/linkarchive/backend/auth/service/OAuthService.java
@@ -97,7 +97,7 @@ public class OAuthService {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", GRANT_TYPE);
         params.add("client_id", CLIENT_ID);
-        params.add("redirect_uri", REDIRECT_URI);
+        params.add("redirect_uri", redirectUri);
         params.add("code", code);
 
         HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);

--- a/src/main/java/project/linkarchive/backend/auth/service/OAuthService.java
+++ b/src/main/java/project/linkarchive/backend/auth/service/OAuthService.java
@@ -97,7 +97,7 @@ public class OAuthService {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", GRANT_TYPE);
         params.add("client_id", CLIENT_ID);
-        params.add("redirect_uri", redirectUri);
+        params.add("redirect_uri", REDIRECT_URI);
         params.add("code", code);
 
         HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);

--- a/src/main/java/project/linkarchive/backend/user/controller/UserApiController.java
+++ b/src/main/java/project/linkarchive/backend/user/controller/UserApiController.java
@@ -11,12 +11,12 @@ import org.springframework.web.multipart.MultipartFile;
 import project.linkarchive.backend.advice.success.SuccessResponse;
 import project.linkarchive.backend.security.AuthInfo;
 import project.linkarchive.backend.user.request.UpdateNickNameRequest;
+import project.linkarchive.backend.user.request.UpdateProfileRequest;
 import project.linkarchive.backend.user.service.UserApiService;
 
 import java.io.IOException;
 
-import static project.linkarchive.backend.advice.success.SuccessCodeConst.UPDATE_NICKNAME;
-import static project.linkarchive.backend.advice.success.SuccessCodeConst.UPDATE_PROFILE_IMAGE;
+import static project.linkarchive.backend.advice.success.SuccessCodeConst.*;
 
 @RestController
 @PreAuthorize("isAuthenticated()")
@@ -28,8 +28,17 @@ public class UserApiController {
         this.userApiService = userApiService;
     }
 
+    @PatchMapping("/user")
+    public ResponseEntity<SuccessResponse> updateUserProfile(
+            @RequestBody UpdateProfileRequest request,
+            AuthInfo authInfo
+    ) {
+        userApiService.updateUserProfile(request, authInfo.getId());
+        return ResponseEntity.ok(new SuccessResponse(UPDATE_USER_PROFILE));
+    }
+
     @PatchMapping("/user/nickname")
-    public ResponseEntity<SuccessResponse> updateUserNickName(
+    public ResponseEntity<SuccessResponse> updateUserNickname(
             @RequestBody UpdateNickNameRequest request,
             AuthInfo authInfo
     ) {

--- a/src/main/java/project/linkarchive/backend/user/domain/User.java
+++ b/src/main/java/project/linkarchive/backend/user/domain/User.java
@@ -8,6 +8,7 @@ import project.linkarchive.backend.advice.entityBase.TimeEntity;
 import project.linkarchive.backend.auth.response.KakaoProfile;
 import project.linkarchive.backend.bookmark.domain.BookMark;
 import project.linkarchive.backend.user.request.UpdateNickNameRequest;
+import project.linkarchive.backend.user.request.UpdateProfileRequest;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -58,8 +59,13 @@ public class User extends TimeEntity {
                 .build();
     }
 
+    public void updateUserProfile(UpdateProfileRequest request) {
+        this.nickname = request.getNickname();
+        this.introduce = request.getIntroduce();
+    }
+    
     public void updateUserNickName(UpdateNickNameRequest request) {
         this.nickname = request.getNickname();
     }
-
+    
 }

--- a/src/main/java/project/linkarchive/backend/user/request/UpdateProfileRequest.java
+++ b/src/main/java/project/linkarchive/backend/user/request/UpdateProfileRequest.java
@@ -1,0 +1,19 @@
+package project.linkarchive.backend.user.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateProfileRequest {
+
+    private String nickname;
+    private String introduce;
+
+    public UpdateProfileRequest(String nickname, String introduce) {
+        this.nickname = nickname;
+        this.introduce = introduce;
+    }
+
+}


### PR DESCRIPTION
## 개요
로그인 유저의 프로필을 수정하는 API에요

## 📌 관련 이슈
#83 

## ✨ 과제 내용
- [ ] 로그인한 유저의 프로필을 수정할 수 있어요
- [ ] 유저의 닉네임 및 자기소개 관련 예외처리 로직을 만들었어요
