### PR TITLE
메타 타입이 아닌 데이터를 크롤링

### DIFF
--- a/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
+++ b/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
@@ -24,6 +24,7 @@ public enum ExceptionCodeConst {
     LENGTH_REQUIRED_TAG(416, "LENGTH_REQUIRED_TAG", "Tag의 길이를 2글자 이상 8글자 이하로 작성해주세요."),
     LENGTH_REQUIRED_NICKNAME(416, "LENGTH_REQUIRED_NICKNAME", "닉네임의 길이를 2글자 이상 16글자 이하로 작성해주세요."),
     LENGTH_REQUIRED_INTRODUCE(416, "LENGTH_REQUIRED_INTRODUCE", "자기소개는 20글자 이하로 작성해주세요."),
+    LENGTH_REQUIRED_TITLE(416, "LENGTH_REQUIRED_TITLE", "링크의 제목을 입력해주세요."),
 
     EXCEEDED_TAG_LIMIT_10(416, "EXCEEDED_TAG_LIMIT", "태그의 개수가 10개를 초과할 수 없습니다."),
     EXCEEDED_TAG_SIZE(416, "EXCEEDED_TAG_SIZE", "해시태그 조회 갯수를 초과했습니다.");

--- a/src/main/java/project/linkarchive/backend/link/controller/LinkQueryController.java
+++ b/src/main/java/project/linkarchive/backend/link/controller/LinkQueryController.java
@@ -62,11 +62,12 @@ public class LinkQueryController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
 
-        String title = document.select("meta[property=og:title]").attr("content");
-        String description = document.select("meta[property=og:description]").attr("content");
-        String thumbnail = document.select("meta[property=og:image]").attr("content");
+        String titleText = document.select("title").text();
+        String metaTitle = document.select("meta[property=og:title]").attr("content");
+        String metaDescription = document.select("meta[property=og:description]").attr("content");
+        String metaThumbnail = document.select("meta[property=og:image]").attr("content");
 
-        LinkMetaDataResponse linkMetaDataResponse = new LinkMetaDataResponse(title, description, thumbnail);
+        LinkMetaDataResponse linkMetaDataResponse = new LinkMetaDataResponse(titleText, metaTitle, metaDescription, metaThumbnail);
         return ResponseEntity.ok(linkMetaDataResponse);
     }
 

--- a/src/main/java/project/linkarchive/backend/link/response/LinkMetaDataResponse.java
+++ b/src/main/java/project/linkarchive/backend/link/response/LinkMetaDataResponse.java
@@ -5,14 +5,16 @@ import lombok.Getter;
 @Getter
 public class LinkMetaDataResponse {
 
-    private String title;
-    private String description;
-    private String thumbnail;
+    private String titleText;
+    private String metaTitle;
+    private String metaDescription;
+    private String metaThumbnail;
 
-    public LinkMetaDataResponse(String title, String description, String thumbnail) {
-        this.title = title;
-        this.description = description;
-        this.thumbnail = thumbnail;
+    public LinkMetaDataResponse(String titleText, String metaTitle, String metaDescription, String metaThumbnail) {
+        this.titleText = titleText;
+        this.metaTitle = metaTitle;
+        this.metaDescription = metaDescription;
+        this.metaThumbnail = metaThumbnail;
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/link/service/LinkApiService.java
+++ b/src/main/java/project/linkarchive/backend/link/service/LinkApiService.java
@@ -25,6 +25,7 @@ import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.*;
 @Transactional
 public class LinkApiService {
 
+    public static final int MINIMUM_TITLE_LENGTH = 1;
     public static final int MINIMUM_TAG_LENGTH = 2;
     public static final int MAXIMUM_TAG_LENGTH = 8;
     public static final int MAX_TAG_COUNT = 10;
@@ -42,6 +43,10 @@ public class LinkApiService {
     }
 
     public void create(CreateLinkRequest request, Long userId) {
+        if (request.getTitle() == null || request.getTitle().length() < MINIMUM_TITLE_LENGTH) {
+            throw new LengthRequiredException(LENGTH_REQUIRED_TITLE);
+        }
+
         User user = findUserById(userId);
         Set<String> tagsFromRequest = getTagsFromRequest(request);
         exceededTagCount(tagsFromRequest);

--- a/src/main/java/project/linkarchive/backend/link/service/LinkApiService.java
+++ b/src/main/java/project/linkarchive/backend/link/service/LinkApiService.java
@@ -43,9 +43,7 @@ public class LinkApiService {
     }
 
     public void create(CreateLinkRequest request, Long userId) {
-        if (request.getTitle() == null || request.getTitle().length() < MINIMUM_TITLE_LENGTH) {
-            throw new LengthRequiredException(LENGTH_REQUIRED_TITLE);
-        }
+        validationTitleLength(request);
 
         User user = findUserById(userId);
         Set<String> tagsFromRequest = getTagsFromRequest(request);
@@ -53,6 +51,12 @@ public class LinkApiService {
 
         Link link = Link.build(request, user);
         addTagsToLinkAndIncrementUserTagCount(tagsFromRequest, link);
+    }
+
+    private void validationTitleLength(CreateLinkRequest request) {
+        if (request.getTitle() == null || request.getTitle().length() < MINIMUM_TITLE_LENGTH) {
+            throw new LengthRequiredException(LENGTH_REQUIRED_TITLE);
+        }
     }
 
     private User findUserById(Long userId) {


### PR DESCRIPTION
## 개요
메타 데이터 크롤링 시 메타 데이터가 없는 경우에 다른 데이터를 크롤링 하는 기능을 추가했어요

## 📌 관련 이슈
close #105 

## ✨ 과제 내용
- [x] 메타 제외한 데이터를 크롤링 하는 기능을 추가했어요.
- [x] 메타 데이터가 없는 경우를 생각해서 링크 생성 시 기본 값인 타이틀에 대한 예외처리 기능을 추가했어요
