### PR TITLE
feat: 프로필 이미지 수정 시 url key값 수정

### DIFF
--- a/src/main/java/project/linkarchive/backend/s3/S3Uploader.java
+++ b/src/main/java/project/linkarchive/backend/s3/S3Uploader.java
@@ -27,17 +27,12 @@ import java.util.UUID;
 @Log4j2
 public class S3Uploader {
 
-    public final static int S3_KEY = 3;
-
     private final AmazonS3 amazonS3;
 
     private final AmazonS3Client amazonS3Client;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
-
-    @Value("${cloud.aws.s3.default-image}")
-    private String defaultImage;
 
     public S3Uploader(AmazonS3 amazonS3, AmazonS3Client amazonS3Client) {
         this.amazonS3 = amazonS3;
@@ -92,10 +87,6 @@ public class S3Uploader {
         long mSec = expiration.getTime();
         mSec += expirationTimeInMinutes;
         expiration.setTime(mSec);
-
-        if (!objectKey.equals(defaultImage)) {
-            objectKey = objectKey.split("/")[S3_KEY];
-        }
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, objectKey)
                 .withMethod(HttpMethod.GET)

--- a/src/main/java/project/linkarchive/backend/s3/S3Uploader.java
+++ b/src/main/java/project/linkarchive/backend/s3/S3Uploader.java
@@ -27,12 +27,17 @@ import java.util.UUID;
 @Log4j2
 public class S3Uploader {
 
+    public final static int S3_KEY = 3;
+
     private final AmazonS3 amazonS3;
 
     private final AmazonS3Client amazonS3Client;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
+
+    @Value("${cloud.aws.s3.default-image}")
+    private String defaultImage;
 
     public S3Uploader(AmazonS3 amazonS3, AmazonS3Client amazonS3Client) {
         this.amazonS3 = amazonS3;
@@ -87,6 +92,10 @@ public class S3Uploader {
         long mSec = expiration.getTime();
         mSec += expirationTimeInMinutes;
         expiration.setTime(mSec);
+
+        if (!objectKey.equals(defaultImage)) {
+            objectKey = objectKey.split("/")[S3_KEY];
+        }
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, objectKey)
                 .withMethod(HttpMethod.GET)

--- a/src/main/java/project/linkarchive/backend/user/service/UserApiService.java
+++ b/src/main/java/project/linkarchive/backend/user/service/UserApiService.java
@@ -75,7 +75,8 @@ public class UserApiService {
         validateNotEmptyFile(image);
         validateContentType(image.getContentType());
 
-        String storedFileName = extractKey(s3Uploader.upload(image));
+        String storedFileName = s3Uploader.upload(image);
+        storedFileName = extractKey(storedFileName);
 
         String oldProfileImageName = profileImage.getProfileImageFilename();
         if (!oldProfileImageName.equals(defaultImage)) {

--- a/src/main/java/project/linkarchive/backend/user/service/UserApiService.java
+++ b/src/main/java/project/linkarchive/backend/user/service/UserApiService.java
@@ -79,8 +79,8 @@ public class UserApiService {
 
         String oldProfileImageName = profileImage.getProfileImageFilename();
         if (!oldProfileImageName.equals(defaultImage)) {
-            String key = extractKey(oldProfileImageName);
-            s3Uploader.deleteFile(key);
+            String oldFilekey = extractKey(oldProfileImageName);
+            s3Uploader.deleteFile(oldFilekey);
         }
 
         profileImage.updateProfileImage(storedFileName);

--- a/src/main/java/project/linkarchive/backend/user/service/UserApiService.java
+++ b/src/main/java/project/linkarchive/backend/user/service/UserApiService.java
@@ -75,12 +75,12 @@ public class UserApiService {
         validateNotEmptyFile(image);
         validateContentType(image.getContentType());
 
-        String storedFileName = s3Uploader.upload(image);
+        String storedFileName = extractKey(s3Uploader.upload(image));
 
         String oldProfileImageName = profileImage.getProfileImageFilename();
         if (!oldProfileImageName.equals(defaultImage)) {
-        String key = oldProfileImageName.split("/")[S3_KEY];
-        s3Uploader.deleteFile(key);
+            String key = extractKey(oldProfileImageName);
+            s3Uploader.deleteFile(key);
         }
 
         profileImage.updateProfileImage(storedFileName);
@@ -159,6 +159,11 @@ public class UserApiService {
                 throw new NotAcceptableException(NOT_ACCEPTABLE_CONTENT_TYPE);
             }
         }
+    }
+
+    private String extractKey(String fileUrl) {
+        String key = fileUrl.split("/")[S3_KEY];
+        return key;
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/user/service/UserApiService.java
+++ b/src/main/java/project/linkarchive/backend/user/service/UserApiService.java
@@ -79,8 +79,8 @@ public class UserApiService {
 
         String oldProfileImageName = profileImage.getProfileImageFilename();
         if (!oldProfileImageName.equals(defaultImage)) {
-            String oldFilekey = extractKey(oldProfileImageName);
-            s3Uploader.deleteFile(oldFilekey);
+            String oldFileKey = extractKey(oldProfileImageName);
+            s3Uploader.deleteFile(oldFileKey);
         }
 
         profileImage.updateProfileImage(storedFileName);


### PR DESCRIPTION
## 개요
프로필 이미지 수정 시 response url 주소가 중복돼서 저장되지 않도록 했습니다.

## 📌 관련 이슈
close #103

## ✨ 과제 내용
- [ ] "https://~"로 저장되어있는 프로필 이름 중 key값만 추출하여 다운로드 유효기간이 설정된 url 로 reponse를 보냅니다.
