### PR TITLE
user Id -> nickname으로 request 요청 값 변환 및 태그 필터링 이슈 확인 후 해결

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,7 @@ jobs:
       shell: bash
       
     - name: 프로젝트 빌드
-      run: ./gradlew clean build --exclude-task test
-      shell: bash
-
-    - name: 테스트 실행
-      run: ./gradlew test
+      run: ./gradlew clean build
       shell: bash
   
   build-and-deploy:
@@ -77,11 +73,7 @@ jobs:
       shell: bash
 
     - name: 프로젝트 빌드
-      run: ./gradlew clean build --exclude-task test
-      shell: bash
-
-    - name: 테스트 실행
-      run: ./gradlew test
+      run: ./gradlew clean build
       shell: bash
       
     - name: Make zip file

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,15 @@ jobs:
       run: chmod +x ./gradlew
       shell: bash
       
-    - name: 프로젝트 빌드
+    - name: Cache Gradle packages 
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+      
+    - name: 프로젝트 빌드 & 테스트 코드
       run: ./gradlew clean build
       shell: bash
   

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,14 @@ jobs:
         distribution: 'corretto'
         cache: gradle
         
+    - name: make application.yml
+      if: contains(github.ref, 'dev') 
+      run: |
+        cd ./src/test/resources
+        touch ./application-test.yml
+        echo "${{ secrets.YML_TEST }}" > ./application-test.yml
+      shell: bash
+        
     - name: gradlew에 실행 권한 부여
       run: chmod +x ./gradlew
       shell: bash

--- a/src/main/java/project/linkarchive/backend/bookmark/controller/BookMarkQueryController.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/controller/BookMarkQueryController.java
@@ -7,9 +7,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import project.linkarchive.backend.bookmark.response.UserMarkListResponse;
 import project.linkarchive.backend.bookmark.service.BookMarkQueryService;
 import project.linkarchive.backend.hashtag.response.TagListResponse;
-import project.linkarchive.backend.link.response.linkList.UserLinkListResponse;
 import project.linkarchive.backend.security.AuthInfo;
 
 @RestController
@@ -22,37 +22,37 @@ public class BookMarkQueryController {
     }
 
     @GetMapping("/mark/links/user")
-    public ResponseEntity<UserLinkListResponse> getUserMarkedLinkList(
+    public ResponseEntity<UserMarkListResponse> getMyMarkLinkList(
             @RequestParam(value = "tag", required = false) String tag,
-            @RequestParam(value = "linkId", required = false) Long lastLinkId,
+            @RequestParam(value = "markId", required = false) Long lastMarkId,
             @PageableDefault Pageable pageable,
             AuthInfo authInfo
     ) {
-        UserLinkListResponse userLinkListResponse = bookMarkQueryService.getUserMarkedLinkList(authInfo.getId(), lastLinkId, pageable, tag);
-        return ResponseEntity.ok(userLinkListResponse);
+        UserMarkListResponse userMarkListResponse = bookMarkQueryService.getMyMarkLinkList(authInfo.getId(), lastMarkId, pageable, tag);
+        return ResponseEntity.ok(userMarkListResponse);
     }
 
     @GetMapping("/mark/links/public/user/{nickname}")
-    public ResponseEntity<UserLinkListResponse> getPublicUserMarkedLinkList(
+    public ResponseEntity<UserMarkListResponse> getPublicUserMarkedLinkList(
             @PathVariable("nickname") String nickname,
             @RequestParam(value = "tag", required = false) String tag,
-            @RequestParam(value = "linkId", required = false) Long lastLinkId,
+            @RequestParam(value = "markId", required = false) Long lastMarkId,
             @PageableDefault Pageable pageable
     ) {
-        UserLinkListResponse userLinkListResponse = bookMarkQueryService.getPublicUserMarkedLinkList(nickname, lastLinkId, pageable, tag);
-        return ResponseEntity.ok(userLinkListResponse);
+        UserMarkListResponse userMarkListResponse = bookMarkQueryService.getPublicUserMarkedLinkList(nickname, lastMarkId, pageable, tag);
+        return ResponseEntity.ok(userMarkListResponse);
     }
 
     @GetMapping("/mark/links/authentication/user/{nickname}")
-    public ResponseEntity<UserLinkListResponse> getAuthenticatedUserMarkedLinkList(
+    public ResponseEntity<UserMarkListResponse> getAuthenticatedUserMarkedLinkList(
             @PathVariable("nickname") String nickname,
             @RequestParam(value = "tag", required = false) String tag,
-            @RequestParam(value = "linkId", required = false) Long lastLinkId,
+            @RequestParam(value = "markId", required = false) Long lastMarkId,
             @PageableDefault Pageable pageable,
             AuthInfo authInfo
     ) {
-        UserLinkListResponse userLinkListResponse = bookMarkQueryService.getAuthenticatedUserMarkedLinkList(nickname, lastLinkId, pageable, authInfo.getId(), tag);
-        return ResponseEntity.ok(userLinkListResponse);
+        UserMarkListResponse userMarkListResponse = bookMarkQueryService.getAuthenticatedUserMarkedLinkList(nickname, lastMarkId, pageable, authInfo.getId(), tag);
+        return ResponseEntity.ok(userMarkListResponse);
     }
 
     @GetMapping("/mark/tags/user/{nickname}")

--- a/src/main/java/project/linkarchive/backend/bookmark/controller/BookMarkQueryController.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/controller/BookMarkQueryController.java
@@ -21,7 +21,6 @@ public class BookMarkQueryController {
         this.bookMarkQueryService = bookMarkQueryService;
     }
 
-    // 내 북마크 리스트 조회 - 로그인 필요 O
     @GetMapping("/mark/links/user")
     public ResponseEntity<UserLinkListResponse> getUserMarkedLinkList(
             @RequestParam(value = "tag", required = false) String tag,
@@ -33,47 +32,43 @@ public class BookMarkQueryController {
         return ResponseEntity.ok(userLinkListResponse);
     }
 
-    // 사용자별 북마크 리스트 조회 - 로그인 필요 X
-    @GetMapping("/mark/links/public/user/{userId}")
+    @GetMapping("/mark/links/public/user/{nickname}")
     public ResponseEntity<UserLinkListResponse> getPublicUserMarkedLinkList(
+            @PathVariable("nickname") String nickname,
             @RequestParam(value = "tag", required = false) String tag,
-            @PathVariable("userId") Long userId,
             @RequestParam(value = "linkId", required = false) Long lastLinkId,
             @PageableDefault Pageable pageable
     ) {
-        UserLinkListResponse userLinkListResponse = bookMarkQueryService.getPublicUserMarkedLinkList(userId, lastLinkId, pageable, tag);
+        UserLinkListResponse userLinkListResponse = bookMarkQueryService.getPublicUserMarkedLinkList(nickname, lastLinkId, pageable, tag);
         return ResponseEntity.ok(userLinkListResponse);
     }
 
-    // 사용자별 북마크 리스트 조회 - 로그인 필요 O
-    @GetMapping("/mark/links/authentication/user/{userId}")
+    @GetMapping("/mark/links/authentication/user/{nickname}")
     public ResponseEntity<UserLinkListResponse> getAuthenticatedUserMarkedLinkList(
+            @PathVariable("nickname") String nickname,
             @RequestParam(value = "tag", required = false) String tag,
-            @PathVariable("userId") Long userId,
             @RequestParam(value = "linkId", required = false) Long lastLinkId,
             @PageableDefault Pageable pageable,
             AuthInfo authInfo
     ) {
-        UserLinkListResponse userLinkListResponse = bookMarkQueryService.getAuthenticatedUserMarkedLinkList(userId, lastLinkId, pageable, authInfo.getId(), tag);
+        UserLinkListResponse userLinkListResponse = bookMarkQueryService.getAuthenticatedUserMarkedLinkList(nickname, lastLinkId, pageable, authInfo.getId(), tag);
         return ResponseEntity.ok(userLinkListResponse);
     }
 
-    // 사용자 별 북마크 리스트 중 해시태그 리스트 조회 011
-    @GetMapping("/marks/tags/user/{userId}")
+    @GetMapping("/mark/tags/user/{nickname}")
     public ResponseEntity<TagListResponse> getMarkTagList(
-            @PathVariable("userId") Long userId
+            @PathVariable("nickname") String nickname
     ) {
-        TagListResponse tagList = bookMarkQueryService.getMarkTagList(userId);
+        TagListResponse tagList = bookMarkQueryService.getMarkTagList(nickname);
         return ResponseEntity.ok(tagList);
     }
 
-    // 사용자 별 북마크 리스트 중 해시태그 N개 조회 009
-    @GetMapping("/marks/limited-tags/user/{userId}")
+    @GetMapping("/mark/limited-tags/user/{nickname}")
     public ResponseEntity<TagListResponse> getMarkTagLimitList(
-            @PathVariable("userId") Long userId,
+            @PathVariable("nickname") String nickname,
             @RequestParam("size") Long size
     ) {
-        TagListResponse tagList = bookMarkQueryService.getMarkTagLimitList(userId, size);
+        TagListResponse tagList = bookMarkQueryService.getMarkTagLimitList(nickname, size);
         return ResponseEntity.ok(tagList);
     }
 

--- a/src/main/java/project/linkarchive/backend/bookmark/repository/BookMarkRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/repository/BookMarkRepositoryImpl.java
@@ -24,7 +24,7 @@ public class BookMarkRepositoryImpl {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
-    public List<LinkResponse> getMarkLinkList(Long userId, Long lastLinkId, Pageable pageable, String tag) {
+    public List<LinkResponse> getMyMarkLinkList(Long userId, Long lastLinkId, Pageable pageable, String tag) {
         return queryFactory
                 .select(new QLinkResponse(
                         bookMark.link.id,
@@ -35,11 +35,31 @@ public class BookMarkRepositoryImpl {
                         bookMark.link.bookMarkCount
                 ))
                 .from(bookMark)
-                .distinct()
-                .leftJoin(bookMark.link, link)
-                .leftJoin(link.linkHashTagList, linkHashTag)
+                .leftJoin(bookMark.link.linkHashTagList, linkHashTag)
                 .where(
                         bookMark.user.id.eq(userId),
+                        ltLinkId(lastLinkId),
+                        containTag(tag)
+                )
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(bookMark.id.desc())
+                .fetch();
+    }
+
+    public List<LinkResponse> getUserMarkLinkList(String nickname, Long lastLinkId, Pageable pageable, String tag) {
+        return queryFactory
+                .select(new QLinkResponse(
+                        bookMark.link.id,
+                        bookMark.link.url,
+                        bookMark.link.title,
+                        bookMark.link.description,
+                        bookMark.link.thumbnail,
+                        bookMark.link.bookMarkCount
+                ))
+                .from(bookMark)
+                .leftJoin(bookMark.link.linkHashTagList, linkHashTag)
+                .where(
+                        bookMark.user.nickname.eq(nickname),
                         ltLinkId(lastLinkId),
                         containTag(tag)
                 )

--- a/src/main/java/project/linkarchive/backend/bookmark/repository/BookMarkRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/repository/BookMarkRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-import project.linkarchive.backend.hashtag.domain.QHashTag;
 import project.linkarchive.backend.link.response.linkList.LinkResponse;
 import project.linkarchive.backend.link.response.linkList.QLinkResponse;
 
@@ -12,7 +11,6 @@ import javax.persistence.EntityManager;
 import java.util.List;
 
 import static project.linkarchive.backend.bookmark.domain.QBookMark.bookMark;
-import static project.linkarchive.backend.hashtag.domain.QHashTag.hashTag;
 import static project.linkarchive.backend.link.domain.QLink.link;
 import static project.linkarchive.backend.link.domain.QLinkHashTag.linkHashTag;
 
@@ -37,7 +35,9 @@ public class BookMarkRepositoryImpl {
                         bookMark.link.bookMarkCount
                 ))
                 .from(bookMark)
+                .distinct()
                 .leftJoin(bookMark.link, link)
+                .leftJoin(link.linkHashTagList, linkHashTag)
                 .where(
                         bookMark.user.id.eq(userId),
                         ltLinkId(lastLinkId),

--- a/src/main/java/project/linkarchive/backend/bookmark/response/MarkResponse.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/response/MarkResponse.java
@@ -1,0 +1,28 @@
+package project.linkarchive.backend.bookmark.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class MarkResponse {
+
+    private Long markId;
+    private Long linkId;
+    private String url;
+    private String title;
+    private String description;
+    private String thumbnail;
+    private Long bookMarkCount;
+
+    @QueryProjection
+    public MarkResponse(Long markId, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount) {
+        this.markId = markId;
+        this.linkId = linkId;
+        this.url = url;
+        this.title = title;
+        this.description = description;
+        this.thumbnail = thumbnail;
+        this.bookMarkCount = bookMarkCount;
+    }
+
+}

--- a/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkListResponse.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkListResponse.java
@@ -1,0 +1,18 @@
+package project.linkarchive.backend.bookmark.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UserMarkListResponse {
+
+    private List<UserMarkResponse> markList;
+    private Boolean hasNext;
+
+    public UserMarkListResponse(List<UserMarkResponse> markList, Boolean hasNext) {
+        this.markList = markList;
+        this.hasNext = hasNext;
+    }
+
+}

--- a/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkResponse.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkResponse.java
@@ -1,0 +1,49 @@
+package project.linkarchive.backend.bookmark.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import project.linkarchive.backend.hashtag.response.TagResponse;
+
+import java.util.List;
+
+@Getter
+public class UserMarkResponse {
+
+    private Long markId;
+    private Long linkId;
+    private String url;
+    private String title;
+    private String description;
+    private String thumbnail;
+    private Long bookMarkCount;
+    private Boolean isRead;
+    private List<TagResponse> tagList;
+
+    @Builder
+    public UserMarkResponse(Long markId, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, Boolean isRead, List<TagResponse> tagList) {
+        this.markId = markId;
+        this.linkId = linkId;
+        this.url = url;
+        this.title = title;
+        this.description = description;
+        this.thumbnail = thumbnail;
+        this.bookMarkCount = bookMarkCount;
+        this.isRead = isRead;
+        this.tagList = tagList;
+    }
+
+    public static UserMarkResponse build(MarkResponse response, Boolean isRead, List<TagResponse> tagList) {
+        return UserMarkResponse.builder()
+                .markId(response.getMarkId())
+                .linkId(response.getLinkId())
+                .url(response.getUrl())
+                .title(response.getTitle())
+                .description(response.getDescription())
+                .thumbnail(response.getThumbnail())
+                .bookMarkCount(response.getBookMarkCount())
+                .isRead(isRead)
+                .tagList(tagList)
+                .build();
+    }
+
+}

--- a/src/main/java/project/linkarchive/backend/bookmark/service/BookMarkQueryService.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/service/BookMarkQueryService.java
@@ -8,14 +8,14 @@ import project.linkarchive.backend.advice.exception.custom.NotFoundException;
 import project.linkarchive.backend.bookmark.domain.BookMark;
 import project.linkarchive.backend.bookmark.repository.BookMarkRepository;
 import project.linkarchive.backend.bookmark.repository.BookMarkRepositoryImpl;
+import project.linkarchive.backend.bookmark.response.MarkResponse;
+import project.linkarchive.backend.bookmark.response.UserMarkListResponse;
+import project.linkarchive.backend.bookmark.response.UserMarkResponse;
 import project.linkarchive.backend.hashtag.response.TagListResponse;
 import project.linkarchive.backend.hashtag.response.TagResponse;
 import project.linkarchive.backend.isLinkRead.repository.IsLinkReadRepository;
 import project.linkarchive.backend.link.domain.LinkHashTag;
 import project.linkarchive.backend.link.repository.LinkHashTagRepository;
-import project.linkarchive.backend.link.response.linkList.LinkResponse;
-import project.linkarchive.backend.link.response.linkList.UserLinkListResponse;
-import project.linkarchive.backend.link.response.linkList.UserLinkResponse;
 import project.linkarchive.backend.user.domain.User;
 import project.linkarchive.backend.user.repository.UserRepository;
 
@@ -48,68 +48,68 @@ public class BookMarkQueryService {
         this.bookMarkRepositoryImpl = bookMarkRepositoryImpl;
     }
 
-    public UserLinkListResponse getUserMarkedLinkList(Long userId, Long lastLinkId, Pageable pageable, String tag) {
+    public UserMarkListResponse getMyMarkLinkList(Long userId, Long lastMarkId, Pageable pageable, String tag) {
         validateUserById(userId);
 
-        List<LinkResponse> linkResponseList = bookMarkRepositoryImpl.getMyMarkLinkList(userId, lastLinkId, pageable, tag);
+        List<MarkResponse> markResponseList = bookMarkRepositoryImpl.getMyMarkLinkList(userId, lastMarkId, pageable, tag);
 
-        boolean hasNext = isHasNextLinkList(pageable, linkResponseList);
+        boolean hasNext = isHasNextLinkList(pageable, markResponseList);
 
-        List<UserLinkResponse> userLinkResponseList = linkResponseList.stream()
-                .map(linkResponse -> {
-                    List<LinkHashTag> linkHashTagList = linkHashTagRepository.findByLinkId(linkResponse.getLinkId());
+        List<UserMarkResponse> userMarkResponseList = markResponseList.stream()
+                .map(markResponse -> {
+                    List<LinkHashTag> linkHashTagList = linkHashTagRepository.findByLinkId(markResponse.getLinkId());
                     List<TagResponse> tagList = linkHashTagList.stream()
                             .map(TagResponse::build)
                             .collect(Collectors.toList());
 
-                    Boolean isRead = isLinkReadRepository.existsByLinkIdAndUserId(linkResponse.getLinkId(), userId);
+                    Boolean isRead = isLinkReadRepository.existsByLinkIdAndUserId(markResponse.getLinkId(), userId);
 
-                    return UserLinkResponse.build(linkResponse, isRead, tagList);
+                    return UserMarkResponse.build(markResponse, isRead, tagList);
                 }).collect(Collectors.toList());
 
-        return new UserLinkListResponse(userLinkResponseList, hasNext);
+        return new UserMarkListResponse(userMarkResponseList, hasNext);
     }
 
-    public UserLinkListResponse getPublicUserMarkedLinkList(String nickname, Long lastLinkId, Pageable pageable, String tag) {
+    public UserMarkListResponse getPublicUserMarkedLinkList(String nickname, Long lastMarkId, Pageable pageable, String tag) {
         validateUserByNickname(nickname);
 
-        List<LinkResponse> linkResponseList = bookMarkRepositoryImpl.getUserMarkLinkList(nickname, lastLinkId, pageable, tag);
+        List<MarkResponse> markResponseList = bookMarkRepositoryImpl.getUserMarkLinkList(nickname, lastMarkId, pageable, tag);
 
-        boolean hasNext = isHasNextLinkList(pageable, linkResponseList);
+        boolean hasNext = isHasNextLinkList(pageable, markResponseList);
 
-        List<UserLinkResponse> userLinkResponseList = linkResponseList.stream()
-                .map(linkResponse -> {
-                    List<LinkHashTag> linkHashTagList = linkHashTagRepository.findByLinkId(linkResponse.getLinkId());
+        List<UserMarkResponse> userMarkResponseList = markResponseList.stream()
+                .map(markResponse -> {
+                    List<LinkHashTag> linkHashTagList = linkHashTagRepository.findByLinkId(markResponse.getLinkId());
                     List<TagResponse> tagList = linkHashTagList.stream()
                             .map(TagResponse::build)
                             .collect(Collectors.toList());
 
-                    return UserLinkResponse.build(linkResponse, false, tagList);
+                    return UserMarkResponse.build(markResponse, false, tagList);
                 }).collect(Collectors.toList());
 
-        return new UserLinkListResponse(userLinkResponseList, hasNext);
+        return new UserMarkListResponse(userMarkResponseList, hasNext);
     }
 
-    public UserLinkListResponse getAuthenticatedUserMarkedLinkList(String nickname, Long lastLinkId, Pageable pageable, Long loginUserId, String tag) {
+    public UserMarkListResponse getAuthenticatedUserMarkedLinkList(String nickname, Long lastMarkId, Pageable pageable, Long loginUserId, String tag) {
         validateUserByNickname(nickname);
 
-        List<LinkResponse> linkResponseList = bookMarkRepositoryImpl.getUserMarkLinkList(nickname, lastLinkId, pageable, tag);
+        List<MarkResponse> markResponseList = bookMarkRepositoryImpl.getUserMarkLinkList(nickname, lastMarkId, pageable, tag);
 
-        boolean hasNext = isHasNextLinkList(pageable, linkResponseList);
+        boolean hasNext = isHasNextLinkList(pageable, markResponseList);
 
-        List<UserLinkResponse> userLinkResponseList = linkResponseList.stream()
-                .map(linkResponse -> {
-                    List<LinkHashTag> linkHashTagList = linkHashTagRepository.findByLinkId(linkResponse.getLinkId());
+        List<UserMarkResponse> userMarkResponseList = markResponseList.stream()
+                .map(markResponse -> {
+                    List<LinkHashTag> linkHashTagList = linkHashTagRepository.findByLinkId(markResponse.getLinkId());
                     List<TagResponse> tagList = linkHashTagList.stream()
                             .map(TagResponse::build)
                             .collect(Collectors.toList());
 
-                    Boolean isRead = isLinkReadRepository.existsByLinkIdAndUserId(linkResponse.getLinkId(), loginUserId);
+                    Boolean isRead = isLinkReadRepository.existsByLinkIdAndUserId(markResponse.getLinkId(), loginUserId);
 
-                    return UserLinkResponse.build(linkResponse, isRead, tagList);
+                    return UserMarkResponse.build(markResponse, isRead, tagList);
                 }).collect(Collectors.toList());
 
-        return new UserLinkListResponse(userLinkResponseList, hasNext);
+        return new UserMarkListResponse(userMarkResponseList, hasNext);
     }
 
     public TagListResponse getMarkTagList(String nickname) {
@@ -178,7 +178,7 @@ public class BookMarkQueryService {
         }
     }
 
-    private boolean isHasNextLinkList(Pageable pageable, List<LinkResponse> linkResponseList) {
+    private boolean isHasNextLinkList(Pageable pageable, List<MarkResponse> linkResponseList) {
         boolean hasNext = false;
         if (linkResponseList.size() > pageable.getPageSize()) {
             linkResponseList.remove(linkResponseList.size() - 1);

--- a/src/main/java/project/linkarchive/backend/bookmark/service/BookMarkQueryService.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/service/BookMarkQueryService.java
@@ -16,6 +16,7 @@ import project.linkarchive.backend.link.repository.LinkHashTagRepository;
 import project.linkarchive.backend.link.response.linkList.LinkResponse;
 import project.linkarchive.backend.link.response.linkList.UserLinkListResponse;
 import project.linkarchive.backend.link.response.linkList.UserLinkResponse;
+import project.linkarchive.backend.user.domain.User;
 import project.linkarchive.backend.user.repository.UserRepository;
 
 import java.util.Comparator;
@@ -48,9 +49,9 @@ public class BookMarkQueryService {
     }
 
     public UserLinkListResponse getUserMarkedLinkList(Long userId, Long lastLinkId, Pageable pageable, String tag) {
-        validateUserExists(userId);
+        validateUserById(userId);
 
-        List<LinkResponse> linkResponseList = bookMarkRepositoryImpl.getMarkLinkList(userId, lastLinkId, pageable, tag);
+        List<LinkResponse> linkResponseList = bookMarkRepositoryImpl.getMyMarkLinkList(userId, lastLinkId, pageable, tag);
 
         boolean hasNext = isHasNextLinkList(pageable, linkResponseList);
 
@@ -69,10 +70,10 @@ public class BookMarkQueryService {
         return new UserLinkListResponse(userLinkResponseList, hasNext);
     }
 
-    public UserLinkListResponse getPublicUserMarkedLinkList(Long userId, Long lastLinkId, Pageable pageable, String tag) {
-        validateUserExists(userId);
+    public UserLinkListResponse getPublicUserMarkedLinkList(String nickname, Long lastLinkId, Pageable pageable, String tag) {
+        validateUserByNickname(nickname);
 
-        List<LinkResponse> linkResponseList = bookMarkRepositoryImpl.getMarkLinkList(userId, lastLinkId, pageable, tag);
+        List<LinkResponse> linkResponseList = bookMarkRepositoryImpl.getUserMarkLinkList(nickname, lastLinkId, pageable, tag);
 
         boolean hasNext = isHasNextLinkList(pageable, linkResponseList);
 
@@ -89,10 +90,10 @@ public class BookMarkQueryService {
         return new UserLinkListResponse(userLinkResponseList, hasNext);
     }
 
-    public UserLinkListResponse getAuthenticatedUserMarkedLinkList(Long userId, Long lastLinkId, Pageable pageable, Long loginUserId, String tag) {
-        validateUserExists(userId);
+    public UserLinkListResponse getAuthenticatedUserMarkedLinkList(String nickname, Long lastLinkId, Pageable pageable, Long loginUserId, String tag) {
+        validateUserByNickname(nickname);
 
-        List<LinkResponse> linkResponseList = bookMarkRepositoryImpl.getMarkLinkList(userId, lastLinkId, pageable, tag);
+        List<LinkResponse> linkResponseList = bookMarkRepositoryImpl.getUserMarkLinkList(nickname, lastLinkId, pageable, tag);
 
         boolean hasNext = isHasNextLinkList(pageable, linkResponseList);
 
@@ -111,10 +112,10 @@ public class BookMarkQueryService {
         return new UserLinkListResponse(userLinkResponseList, hasNext);
     }
 
-    public TagListResponse getMarkTagList(Long userId) {
-        validateUserExists(userId);
+    public TagListResponse getMarkTagList(String nickname) {
+        User user = getUserByNickname(nickname);
 
-        List<BookMark> bookMarkList = bookMarkRepository.findByUserId(userId);
+        List<BookMark> bookMarkList = bookMarkRepository.findByUserId(user.getId());
 
         Map<String, Integer> tagCountMap = new HashMap<>();
         bookMarkList.forEach(bookMark -> {
@@ -133,10 +134,10 @@ public class BookMarkQueryService {
         return new TagListResponse(tagList);
     }
 
-    public TagListResponse getMarkTagLimitList(Long userId, Long size) {
-        validateUserExists(userId);
+    public TagListResponse getMarkTagLimitList(String nickname, Long size) {
+        User user = getUserByNickname(nickname);
         validateSizeDoesNotExceedMax(size);
-        List<BookMark> bookMarkList = bookMarkRepository.findByUserId(userId);
+        List<BookMark> bookMarkList = bookMarkRepository.findByUserId(user.getId());
 
         Map<String, Integer> tagCountMap = new HashMap<>();
         bookMarkList.forEach(bookMark -> {
@@ -156,8 +157,18 @@ public class BookMarkQueryService {
         return new TagListResponse(tagList);
     }
 
-    private void validateUserExists(Long userId) {
+    private void validateUserById(Long userId) {
         userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
+    }
+
+    private void validateUserByNickname(String nickname) {
+        userRepository.findByNickname(nickname)
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
+    }
+
+    private User getUserByNickname(String nickname) {
+        return userRepository.findByNickname(nickname)
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
     }
 

--- a/src/main/java/project/linkarchive/backend/config/WebConfig.java
+++ b/src/main/java/project/linkarchive/backend/config/WebConfig.java
@@ -13,8 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins(
                         "https://localhost:3000",
                         "https://dev.link-archive.com",
-                        "https://www.link-archive.com",
-                        "https://front-12t545pry-link-archive.vercel.app"
+                        "https://www.link-archive.com"
                 )
                 .allowedMethods("GET", "POST", "PATCH", "DELETE")
                 .allowedHeaders("Access-Control-Allow-Origin",

--- a/src/main/java/project/linkarchive/backend/hashtag/response/TagResponse.java
+++ b/src/main/java/project/linkarchive/backend/hashtag/response/TagResponse.java
@@ -26,6 +26,7 @@ public class TagResponse {
 
     public static TagResponse build(LinkHashTag linkHashTag) {
         return TagResponse.builder()
+                .tagId(linkHashTag.getHashTag().getId())
                 .tagName(linkHashTag.getHashTag().getTag())
                 .build();
     }

--- a/src/main/java/project/linkarchive/backend/link/controller/LinkQueryController.java
+++ b/src/main/java/project/linkarchive/backend/link/controller/LinkQueryController.java
@@ -71,44 +71,40 @@ public class LinkQueryController {
         return ResponseEntity.ok(linkMetaDataResponse);
     }
 
-    // 내 링크 리스트 조회 - 로그인 필요 O
     @GetMapping("/links/user")
-    public ResponseEntity<UserLinkListResponse> getUserLinkList(
+    public ResponseEntity<UserLinkListResponse> getMyLinkList(
             @RequestParam(value = "tag", required = false) String tag,
             @RequestParam(value = "linkId", required = false) Long lastLinkId,
             @PageableDefault Pageable pageable,
             AuthInfo authInfo
     ) {
-        UserLinkListResponse userLinkListResponse = linkQueryService.getUserLinkList(authInfo.getId(), pageable, lastLinkId, tag);
+        UserLinkListResponse userLinkListResponse = linkQueryService.getMyLinkList(authInfo.getId(), pageable, lastLinkId, tag);
         return ResponseEntity.ok(userLinkListResponse);
     }
 
-    // 다른 사용자 링크 리스트 조회 - 로그인 필요 X
-    @GetMapping("/links/public/user/{userId}")
+    @GetMapping("/links/public/user/{nickname}")
     public ResponseEntity<UserLinkListResponse> getPublicUserLinkList(
-            @PathVariable("userId") Long userId,
+            @PathVariable("nickname") String nickname,
             @RequestParam(value = "tag", required = false) String tag,
             @RequestParam(value = "linkId", required = false) Long lastLinkId,
             @PageableDefault Pageable pageable
     ) {
-        UserLinkListResponse userLinkListResponse = linkQueryService.getPublicUserLinkList(userId, pageable, lastLinkId, tag);
+        UserLinkListResponse userLinkListResponse = linkQueryService.getPublicUserLinkList(nickname, pageable, lastLinkId, tag);
         return ResponseEntity.ok(userLinkListResponse);
     }
 
-    // 다른 사용자 링크 리스트 조회 - 로그인 필요 O
-    @GetMapping("/links/authentication/user/{userId}")
+    @GetMapping("/links/authentication/user/{nickname}")
     public ResponseEntity<UserLinkListResponse> getAuthenticatedUserLinkList(
-            @PathVariable("userId") Long userId,
+            @PathVariable("nickname") String nickname,
             @RequestParam(value = "tag", required = false) String tag,
             @RequestParam(value = "linkId", required = false) Long lastLinkId,
             @PageableDefault Pageable pageable,
             AuthInfo authInfo
     ) {
-        UserLinkListResponse userLinkListResponse = linkQueryService.getAuthenticatedUserLinkList(userId, pageable, lastLinkId, authInfo.getId(), tag);
+        UserLinkListResponse userLinkListResponse = linkQueryService.getAuthenticatedUserLinkList(nickname, pageable, lastLinkId, authInfo.getId(), tag);
         return ResponseEntity.ok(userLinkListResponse);
     }
 
-    // 사용자들의 링크 둘러보기 - 로그인 필요 X
     @GetMapping("/links/archive/public")
     public ResponseEntity<UserLinkArchiveResponse> getPublicLinkArchive(
             @RequestParam(value = "tag", required = false) String tag,
@@ -119,7 +115,6 @@ public class LinkQueryController {
         return ResponseEntity.ok(userLinkArchiveResponse);
     }
 
-    // 사용자들의 링크 둘러보기 - 로그인 필요 O
     @GetMapping("/links/archive/authentication")
     public ResponseEntity<UserLinkArchiveResponse> getAuthenticatedLinkArchive(
             @RequestParam(value = "tag", required = false) String tag,

--- a/src/main/java/project/linkarchive/backend/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/link/repository/LinkRepositoryImpl.java
@@ -12,9 +12,9 @@ import project.linkarchive.backend.link.response.linkarchive.QArchiveResponse;
 import javax.persistence.EntityManager;
 import java.util.List;
 
-import static project.linkarchive.backend.hashtag.domain.QHashTag.hashTag;
 import static project.linkarchive.backend.link.domain.QLink.link;
 import static project.linkarchive.backend.link.domain.QLinkHashTag.linkHashTag;
+import static project.linkarchive.backend.user.domain.QProfileImage.profileImage;
 
 @Repository
 public class LinkRepositoryImpl {
@@ -36,6 +36,8 @@ public class LinkRepositoryImpl {
                         link.bookMarkCount
                 ))
                 .from(link)
+                .distinct()
+                .leftJoin(link.linkHashTagList, linkHashTag)
                 .where(
                         link.user.id.eq(userId),
                         ltUrlId(lastLinkLid),
@@ -60,8 +62,9 @@ public class LinkRepositoryImpl {
                         link.bookMarkCount
                 ))
                 .from(link)
-                .leftJoin(link.user)
-                .leftJoin(link.user.profileImage)
+                .distinct()
+                .leftJoin(link.user.profileImage, profileImage)
+                .leftJoin(link.linkHashTagList, linkHashTag)
                 .where(
                         ltUrlId(lastLinkId),
                         containTag(tag)

--- a/src/main/java/project/linkarchive/backend/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/link/repository/LinkRepositoryImpl.java
@@ -25,7 +25,7 @@ public class LinkRepositoryImpl {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
-    public List<LinkResponse> getUserLinkList(Long userId, Pageable pageable, Long lastLinkLid, String tag) {
+    public List<LinkResponse> getMyLinkList(Long userId, Pageable pageable, Long lastLinkLid, String tag) {
         return queryFactory
                 .select(new QLinkResponse(
                         link.id,
@@ -40,6 +40,29 @@ public class LinkRepositoryImpl {
                 .leftJoin(link.linkHashTagList, linkHashTag)
                 .where(
                         link.user.id.eq(userId),
+                        ltUrlId(lastLinkLid),
+                        containTag(tag)
+                )
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(link.id.desc())
+                .fetch();
+    }
+
+    public List<LinkResponse> getUserLinkList(String nickname, Pageable pageable, Long lastLinkLid, String tag) {
+        return queryFactory
+                .select(new QLinkResponse(
+                        link.id,
+                        link.url,
+                        link.title,
+                        link.description,
+                        link.thumbnail,
+                        link.bookMarkCount
+                ))
+                .from(link)
+                .distinct()
+                .leftJoin(link.linkHashTagList, linkHashTag)
+                .where(
+                        link.user.nickname.eq(nickname),
                         ltUrlId(lastLinkLid),
                         containTag(tag)
                 )

--- a/src/main/java/project/linkarchive/backend/link/response/linkList/UserLinkResponse.java
+++ b/src/main/java/project/linkarchive/backend/link/response/linkList/UserLinkResponse.java
@@ -9,8 +9,8 @@ import java.util.List;
 @Getter
 public class UserLinkResponse {
 
-    private Long urlId;
-    private String link;
+    private Long linkId;
+    private String url;
     private String title;
     private String description;
     private String thumbnail;
@@ -19,9 +19,9 @@ public class UserLinkResponse {
     private List<TagResponse> tagList;
 
     @Builder
-    public UserLinkResponse(Long urlId, String link, String title, String description, String thumbnail, Long bookMarkCount, Boolean isRead, List<TagResponse> tagList) {
-        this.urlId = urlId;
-        this.link = link;
+    public UserLinkResponse(Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, Boolean isRead, List<TagResponse> tagList) {
+        this.linkId = linkId;
+        this.url = url;
         this.title = title;
         this.description = description;
         this.thumbnail = thumbnail;
@@ -32,8 +32,8 @@ public class UserLinkResponse {
 
     public static UserLinkResponse build(LinkResponse response, Boolean isRead, List<TagResponse> tagList) {
         return UserLinkResponse.builder()
-                .urlId(response.getLinkId())
-                .link(response.getUrl())
+                .linkId(response.getLinkId())
+                .url(response.getUrl())
                 .title(response.getTitle())
                 .description(response.getDescription())
                 .thumbnail(response.getThumbnail())

--- a/src/main/java/project/linkarchive/backend/user/controller/UserQueryController.java
+++ b/src/main/java/project/linkarchive/backend/user/controller/UserQueryController.java
@@ -21,15 +21,15 @@ public class UserQueryController {
     public ResponseEntity<ProfileResponse> getProfile(
             AuthInfo authInfo
     ) {
-        ProfileResponse profileResponse = userQueryService.getUserProfile(authInfo.getId());
+        ProfileResponse profileResponse = userQueryService.getMyProfile(authInfo.getId());
         return ResponseEntity.ok(profileResponse);
     }
 
-    @GetMapping("/user/{userId}")
+    @GetMapping("/user/{nickname}")
     public ResponseEntity<ProfileResponse> getUserProfile(
-            @PathVariable(value = "userId") Long userId
+            @PathVariable("nickname") String nickname
     ) {
-        ProfileResponse profileResponse = userQueryService.getUserProfile(userId);
+        ProfileResponse profileResponse = userQueryService.getUserProfile(nickname);
         return ResponseEntity.ok(profileResponse);
     }
 

--- a/src/main/java/project/linkarchive/backend/user/repository/UserRepository.java
+++ b/src/main/java/project/linkarchive/backend/user/repository/UserRepository.java
@@ -4,11 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import project.linkarchive.backend.user.domain.User;
 
 import java.util.Optional;
-import java.util.OptionalInt;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-
-    Optional<User> findById(Long id);
 
     Optional<User> findBySocialId(String socialId);
 


### PR DESCRIPTION
## 개요
클라이언트 요청으로 리퀘스트 시 id 에서 nickname으로 변경해줬어요

## 📌 관련 이슈
테스트 하다 태그 필터링 이슈 확인해서 바로 해결했어요..!

## ✨ 과제 내용
- [ ] 요청 받은 API를 userId에서 nickname으로 request를 변경해줬어요
- [ ] 태그 필터링 시 문제가 있던 조인을 해결하고 distinct를 추가해서 중복 데이터를 제거해줬어요
