### PR TITLE
Feat/token validation

### DIFF
--- a/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
+++ b/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum ExceptionCodeConst {
 
     NOT_TOKEN(400, "NOT_TOKEN", "토큰이 없습니다."),
+    ACCESS_TOKEN_STILL_VALID(400, "ACCESS_TOKEN_STILL_VALID", "엑세스 토큰의 만료시간이 남아있습니다."),
 
     INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     INVALID_AUTHORIZATION_CODE(401, "INVALID_AUTHORIZATION_CODE", "잘못된 인가코드입니다."),

--- a/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
+++ b/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
@@ -8,7 +8,7 @@ public enum ExceptionCodeConst {
     NOT_TOKEN(400, "NOT_TOKEN", "토큰이 없습니다."),
     ACCESS_TOKEN_STILL_VALID(400, "ACCESS_TOKEN_STILL_VALID", "엑세스 토큰의 만료시간이 남아있습니다."),
 
-    INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+    INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다. 로그인이 필요합니다."),
     INVALID_AUTHORIZATION_CODE(401, "INVALID_AUTHORIZATION_CODE", "잘못된 인가코드입니다."),
 
     FORBIDDEN_ACCESS(403, "FORBIDDEN_ACCESS","권한이 없습니다."),

--- a/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
+++ b/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
@@ -4,8 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum ExceptionCodeConst {
-
-    NOT_TOKEN(400, "NOT_TOKEN", "토큰이 없습니다."),
+    BAD_REQUEST_TOKEN(400, "BAD_REQUEST_TOKEN", "잘못된 토큰 요청입니다."),
     ACCESS_TOKEN_STILL_VALID(400, "ACCESS_TOKEN_STILL_VALID", "엑세스 토큰의 만료시간이 남아있습니다."),
 
     INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다. 로그인이 필요합니다."),
@@ -14,6 +13,7 @@ public enum ExceptionCodeConst {
     FORBIDDEN_ACCESS(403, "FORBIDDEN_ACCESS","권한이 없습니다."),
 
     NOT_FOUND_USER(404, "NOT_FOUND_USER", "유저가 존재하지 않습니다."),
+    NOT_FOUND_TOKEN(404, "NOT_FOUND_TOKEN", "토큰이 존재하지 않습니다."),
     NOT_FOUND_PROFILE_IMAGE(404, "NOT_FOUND_PROFILE_IMAGE", "프로필 이미지가 존재하지 않습니다."),
     NOT_FOUND_LINK(404, "NOT_FOUND_URL", "존재하지 않는 Link 입니다."),
     NOT_FOUND_BOOKMARK(404, "NOT_FOUND_BOOKMARK", "존재하지 않는 북마크입니다."),

--- a/src/main/java/project/linkarchive/backend/auth/controller/OAuthController.java
+++ b/src/main/java/project/linkarchive/backend/auth/controller/OAuthController.java
@@ -33,9 +33,7 @@ public class OAuthController {
 
         LoginResponse loginResponse = oAuthService.login(code, redirectUri, userAgent);
 
-        return ResponseEntity.ok()
-                .header(HEADER_STRING, TOKEN_PREFIX + loginResponse.getAccessToken())
-                .body(loginResponse);
+        return ResponseEntity.ok().body(loginResponse);
     }
 
     @PostMapping("/publish/access-token")
@@ -52,4 +50,5 @@ public class OAuthController {
     ) {
         return oAuthService.publishRefreshToken(refreshToken);
     }
+
 }

--- a/src/main/java/project/linkarchive/backend/auth/controller/OAuthController.java
+++ b/src/main/java/project/linkarchive/backend/auth/controller/OAuthController.java
@@ -40,9 +40,10 @@ public class OAuthController {
 
     @PostMapping("/publish/access-token")
     public AccessTokenResponse publishAccessToken(
-            @RequestHeader("Authorization") String refreshToken
+            @RequestHeader("Authorization") String refreshToken,
+            @RequestHeader("accessToken") String accessToken
     ) {
-        return oAuthService.publishAccessToken(refreshToken);
+        return oAuthService.publishAccessToken(accessToken, refreshToken);
     }
 
     @PostMapping("/publish/refresh-token")

--- a/src/main/java/project/linkarchive/backend/auth/service/OAuthService.java
+++ b/src/main/java/project/linkarchive/backend/auth/service/OAuthService.java
@@ -69,8 +69,8 @@ public class OAuthService {
         }
     }
 
-    public AccessTokenResponse publishAccessToken(String refreshToken) {
-        return jwtUtil.publishAccessToken(refreshToken);
+    public AccessTokenResponse publishAccessToken(String accessToken, String refreshToken) {
+        return jwtUtil.publishAccessToken(accessToken,refreshToken);
     }
 
     public RefreshTokenResponse publishRefreshToken(String refreshToken) {

--- a/src/main/java/project/linkarchive/backend/security/SecurityExceptionHandler.java
+++ b/src/main/java/project/linkarchive/backend/security/SecurityExceptionHandler.java
@@ -33,8 +33,8 @@ public class SecurityExceptionHandler implements AuthenticationEntryPoint, Acces
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         ExceptionCodeConst exception = (ExceptionCodeConst) request.getAttribute("exception");
 
-        if (exception.equals(NOT_TOKEN)) {
-            handler.resolveException(request, response, null, new InvalidException(NOT_TOKEN));
+        if (exception.equals(BAD_REQUEST_TOKEN)) {
+            handler.resolveException(request, response, null, new InvalidException(BAD_REQUEST_TOKEN));
         }
 
         if (exception.equals(INVALID_TOKEN)) {

--- a/src/main/java/project/linkarchive/backend/security/TokenAuthenticationFilter.java
+++ b/src/main/java/project/linkarchive/backend/security/TokenAuthenticationFilter.java
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.INVALID_TOKEN;
-import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.NOT_TOKEN;
+import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.BAD_REQUEST_TOKEN;
 
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
@@ -33,7 +33,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         String tokenHeader = request.getHeader("Authorization");
 
         if (tokenHeader == null) {
-            request.setAttribute("exception", NOT_TOKEN);
+            request.setAttribute("exception", BAD_REQUEST_TOKEN);
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/project/linkarchive/backend/util/JwtUtil.java
+++ b/src/main/java/project/linkarchive/backend/util/JwtUtil.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import lombok.extern.slf4j.Slf4j;
+import org.aspectj.weaver.ast.Not;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -34,7 +34,6 @@ import java.util.Date;
 import static org.springframework.http.HttpMethod.POST;
 import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.*;
 
-@Slf4j
 @Component
 public class JwtUtil {
 
@@ -156,6 +155,57 @@ public class JwtUtil {
         return userId;
     }
 
+    public AccessTokenResponse publishAccessToken(String accessToken, String refreshToken) {
+        String getAccessToken = getTokenWithoutBearer(accessToken);
+        String getRefreshToken = getTokenWithoutBearer(refreshToken);
+        RefreshToken savedRefreshToken;
+
+        if (!isValidatedToken(getAccessToken)) {
+            savedRefreshToken = refreshTokenRepository.findByRefreshToken(getRefreshToken)
+                    .orElseThrow(() -> new UnauthorizedException(INVALID_TOKEN));
+        } else {
+            throw new InvalidException(ACCESS_TOKEN_STILL_VALID);
+        }
+
+        if (isValidatedToken(getRefreshToken)) {
+            User user = userRepository.findById(savedRefreshToken.getUser().getId())
+                    .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
+            String newAccessToken = createAccessToken(user);
+
+            return new AccessTokenResponse(newAccessToken);
+        } else {
+            throw new UnauthorizedException(INVALID_TOKEN);
+        }
+
+    }
+
+    public RefreshTokenResponse publishRefreshToken(String refreshToken) {
+        String getRefreshToken = getTokenWithoutBearer(refreshToken);
+
+        RefreshToken findRefreshToken = refreshTokenRepository.findByRefreshToken(getRefreshToken)
+            .orElseThrow(() -> new UnauthorizedException(INVALID_TOKEN));
+        User user;
+
+        if (isValidatedToken(getRefreshToken)) {
+            user = userRepository.findById(findRefreshToken.getUser().getId())
+                    .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
+        } else {
+            throw new UnauthorizedException(INVALID_TOKEN);
+        }
+
+        if (refreshTokenRepository.existsByUserIdAndAgent(findRefreshToken.getUser().getId(), findRefreshToken.getAgent())) {
+            String newAccessToken = createAccessToken(user);
+            String newRefreshToken = createRefreshToken(user);
+
+            RefreshToken refreshedToken = RefreshToken.build(newRefreshToken, findRefreshToken.getAgent(), user);
+            findRefreshToken.updateRefreshToken(refreshedToken);
+
+            return new RefreshTokenResponse(newAccessToken, newRefreshToken);
+        } else {
+            throw new NotFoundException(NOT_FOUND_TOKEN);
+        }
+    }
+
     public boolean isValidatedToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token);
@@ -165,60 +215,15 @@ public class JwtUtil {
         }
     }
 
-    public AccessTokenResponse publishAccessToken(String accessToken, String refreshToken) {
-        String accessTokenWithoutBearer = getOnlyToken(accessToken);
-        String refreshTokenWithoutBearer = getOnlyToken(refreshToken);
-
-        if (!isValidatedToken(accessTokenWithoutBearer)) { // 엑세스 토큰이 유효하지 않을 떄 엑세스 토큰을 새로 발급할 수 있음
-            RefreshToken savedRefreshToken = refreshTokenRepository.findByRefreshToken(refreshTokenWithoutBearer)
-                    .orElseThrow(() -> new UnauthorizedException(INVALID_TOKEN));
-
-            if (isValidatedToken(refreshTokenWithoutBearer)) { // + 엑세스 토큰을 새로 발급하기 위해서는 리프레시 토큰은 유효해야함
-                User user = userRepository.findById(savedRefreshToken.getUser().getId())
-                        .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
-
-                String newAccessToken = createAccessToken(user);
-
-                return new AccessTokenResponse(newAccessToken);
-            } else {
-                throw new UnauthorizedException(INVALID_TOKEN);
-            }
-        }
-        throw new InvalidException(ACCESS_TOKEN_STILL_VALID);
-    }
-
-    public RefreshTokenResponse publishRefreshToken(String refreshToken) {
-        String refreshTokenWithoutBearer = getOnlyToken(refreshToken);
-
-        RefreshToken savedRefreshToken = refreshTokenRepository.findByRefreshToken(refreshTokenWithoutBearer)
-                .orElseThrow(() -> new UnauthorizedException(INVALID_TOKEN));
-
-        if (isValidatedToken(refreshTokenWithoutBearer)) {
-            User user = userRepository.findById(savedRefreshToken.getUser().getId())
-                    .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
-
-            String newAccessToken = createAccessToken(user);
-            String newRefreshToken = createRefreshToken(user);
-
-            if (refreshTokenRepository.existsByUserIdAndAgent(savedRefreshToken.getUser().getId(), savedRefreshToken.getAgent())) {
-                RefreshToken refreshedToken = RefreshToken.build(newRefreshToken, savedRefreshToken.getAgent(), user);
-                savedRefreshToken.updateRefreshToken(refreshedToken);
-            }
-
-            return new RefreshTokenResponse(newAccessToken, newRefreshToken);
-        } else {
-            throw new UnauthorizedException(INVALID_TOKEN);
-        }
-    }
-
     private Key getSigningKey() {
         return Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
     }
 
-    private String getOnlyToken(String token) {
+    private String getTokenWithoutBearer(String token) {
         String[] tokenData = token.split(BLANK);
         String tokenWithoutBearer = tokenData[TOKEN_DATA_INDEX];
 
         return tokenWithoutBearer;
     }
+
 }


### PR DESCRIPTION
## 개요
refreshToken이 탈취되었을경우 accessToken 재발급 부정 사용을 방지하기위해 
accessToken이 유효한 경우에 재발급 api를 요청한 경우 재발급하지 않는 로직을 추가했습니다.

🚨 accessToken의 유효시간은 악의적 사용자가 조작?해서 만료된 토큰으로 생성할 수 있기 때문에 완전한 해결책은 아니라고 생각됩니다..!!

## 📌 관련 이슈
close #147

## ✨ 과제 내용
- [ ] accessToken, refreshToken 둘 다 requestHeader로 받고  accessToken와 refreshToken의 유효시간(만료시간)을 확인합니다.
- [ ] accessToken 만료시간이 남아있는데 요청한 경우 비정상적인 api 호출로 판단해서 예외처리합니다.
