### PR TITLE
feat: 카카오 프로필 클래스 분리

### DIFF
--- a/src/main/java/project/linkarchive/backend/auth/response/KakaoAccount.java
+++ b/src/main/java/project/linkarchive/backend/auth/response/KakaoAccount.java
@@ -1,7 +1,6 @@
 package project.linkarchive.backend.auth.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,16 +8,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class KakaoProfile {
+public class KakaoAccount {
 
-    public String id;
+    public String email;
 
-    @JsonProperty("kakao_account")
-    public KakaoAccount kakaoAccount;
-
-    public KakaoProfile(String id, KakaoAccount kakaoAccount) {
-        this.id = id;
-        this.kakaoAccount= kakaoAccount;
+    public KakaoAccount(String email){
+        this.email = email;
     }
-
 }

--- a/src/main/java/project/linkarchive/backend/auth/response/KakaoEmail.java
+++ b/src/main/java/project/linkarchive/backend/auth/response/KakaoEmail.java
@@ -8,11 +8,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class KakaoAccount {
+public class KakaoEmail {
 
     public String email;
 
-    public KakaoAccount(String email){
+    public KakaoEmail(String email){
         this.email = email;
     }
 }

--- a/src/main/java/project/linkarchive/backend/auth/response/KakaoProfile.java
+++ b/src/main/java/project/linkarchive/backend/auth/response/KakaoProfile.java
@@ -14,11 +14,11 @@ public class KakaoProfile {
     public String id;
 
     @JsonProperty("kakao_account")
-    public KakaoAccount kakaoAccount;
+    public KakaoEmail kakaoEmail;
 
-    public KakaoProfile(String id, KakaoAccount kakaoAccount) {
+    public KakaoProfile(String id, KakaoEmail kakaoEmail) {
         this.id = id;
-        this.kakaoAccount= kakaoAccount;
+        this.kakaoEmail = kakaoEmail;
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/user/domain/User.java
+++ b/src/main/java/project/linkarchive/backend/user/domain/User.java
@@ -56,7 +56,7 @@ public class User extends TimeEntity {
         return User.builder()
                 .socialId(kakaoProfile.id)
                 .nickname("")
-                .email(kakaoProfile.getKakaoAccount().getEmail())
+                .email(kakaoProfile.getKakaoEmail().getEmail())
                 .introduce("")
                 .build();
     }


### PR DESCRIPTION
## 개요
카카오 유저 프로필 정보가 있는 클래스를 중첩 클래스에서 단독 클래스로 분리했어요

## 📌 관련 이슈
close #157 


## ✨ 과제 내용
- [x] kakao 소셜 아이디와 이메일 정보가 있는 클래스를 각각 분리했습니다.
