### PR TITLE
link 관련 query 조회 시 링크 상태 & 업데이트 시간 Response 필드 추가

### DIFF
--- a/src/main/java/project/linkarchive/backend/bookmark/repository/BookMarkRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/repository/BookMarkRepositoryImpl.java
@@ -33,7 +33,6 @@ public class BookMarkRepositoryImpl {
                         bookMark.link.description,
                         bookMark.link.thumbnail,
                         bookMark.link.bookMarkCount,
-                        bookMark.link.linkStatus,
                         bookMark.createdAt
                 ))
                 .from(bookMark)
@@ -60,7 +59,6 @@ public class BookMarkRepositoryImpl {
                         bookMark.link.description,
                         bookMark.link.thumbnail,
                         bookMark.link.bookMarkCount,
-                        bookMark.link.linkStatus,
                         bookMark.createdAt
                 ))
                 .from(bookMark)

--- a/src/main/java/project/linkarchive/backend/bookmark/repository/BookMarkRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/repository/BookMarkRepositoryImpl.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static project.linkarchive.backend.bookmark.domain.QBookMark.bookMark;
 import static project.linkarchive.backend.link.domain.QLinkHashTag.linkHashTag;
+import static project.linkarchive.backend.link.enums.LinkStatus.ACTIVE;
 
 @Repository
 public class BookMarkRepositoryImpl {
@@ -40,6 +41,7 @@ public class BookMarkRepositoryImpl {
                 .leftJoin(bookMark.link.linkHashTagList, linkHashTag)
                 .where(
                         bookMark.user.id.eq(userId),
+                        bookMark.link.linkStatus.eq(ACTIVE),
                         ltLinkId(lastMarkId),
                         containTag(tag)
                 )
@@ -64,6 +66,7 @@ public class BookMarkRepositoryImpl {
                 .from(bookMark)
                 .where(
                         bookMark.user.nickname.eq(nickname),
+                        bookMark.link.linkStatus.eq(ACTIVE),
                         ltLinkId(lastMarkId),
                         containTag(tag)
                 )

--- a/src/main/java/project/linkarchive/backend/bookmark/repository/BookMarkRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/repository/BookMarkRepositoryImpl.java
@@ -32,6 +32,7 @@ public class BookMarkRepositoryImpl {
                         bookMark.link.description,
                         bookMark.link.thumbnail,
                         bookMark.link.bookMarkCount,
+                        bookMark.link.linkStatus,
                         bookMark.createdAt
                 ))
                 .from(bookMark)
@@ -57,6 +58,7 @@ public class BookMarkRepositoryImpl {
                         bookMark.link.description,
                         bookMark.link.thumbnail,
                         bookMark.link.bookMarkCount,
+                        bookMark.link.linkStatus,
                         bookMark.createdAt
                 ))
                 .from(bookMark)

--- a/src/main/java/project/linkarchive/backend/bookmark/response/MarkResponse.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/response/MarkResponse.java
@@ -2,7 +2,6 @@ package project.linkarchive.backend.bookmark.response;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
-import project.linkarchive.backend.link.enums.LinkStatus;
 
 import java.time.LocalDateTime;
 
@@ -16,11 +15,10 @@ public class MarkResponse {
     private String description;
     private String thumbnail;
     private Long bookMarkCount;
-    private LinkStatus linkStatus;
     private LocalDateTime bookMarkedTime;
 
     @QueryProjection
-    public MarkResponse(Long markId, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LinkStatus linkStatus, LocalDateTime bookMarkedTime) {
+    public MarkResponse(Long markId, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LocalDateTime bookMarkedTime) {
         this.markId = markId;
         this.linkId = linkId;
         this.url = url;
@@ -28,7 +26,6 @@ public class MarkResponse {
         this.description = description;
         this.thumbnail = thumbnail;
         this.bookMarkCount = bookMarkCount;
-        this.linkStatus = linkStatus;
         this.bookMarkedTime = bookMarkedTime;
     }
 

--- a/src/main/java/project/linkarchive/backend/bookmark/response/MarkResponse.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/response/MarkResponse.java
@@ -2,6 +2,7 @@ package project.linkarchive.backend.bookmark.response;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
+import project.linkarchive.backend.link.enums.LinkStatus;
 
 import java.time.LocalDateTime;
 
@@ -15,10 +16,11 @@ public class MarkResponse {
     private String description;
     private String thumbnail;
     private Long bookMarkCount;
+    private LinkStatus linkStatus;
     private LocalDateTime bookMarkedTime;
 
     @QueryProjection
-    public MarkResponse(Long markId, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LocalDateTime bookMarkedTime) {
+    public MarkResponse(Long markId, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LinkStatus linkStatus, LocalDateTime bookMarkedTime) {
         this.markId = markId;
         this.linkId = linkId;
         this.url = url;
@@ -26,6 +28,7 @@ public class MarkResponse {
         this.description = description;
         this.thumbnail = thumbnail;
         this.bookMarkCount = bookMarkCount;
+        this.linkStatus = linkStatus;
         this.bookMarkedTime = bookMarkedTime;
     }
 

--- a/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkResponse.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkResponse.java
@@ -3,7 +3,6 @@ package project.linkarchive.backend.bookmark.response;
 import lombok.Builder;
 import lombok.Getter;
 import project.linkarchive.backend.hashtag.response.TagResponse;
-import project.linkarchive.backend.link.enums.LinkStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,14 +17,13 @@ public class UserMarkResponse {
     private String description;
     private String thumbnail;
     private Long bookMarkCount;
-    private LinkStatus linkStatus;
     private Boolean isRead;
     private Boolean isMark;
     private List<TagResponse> tagList;
     private LocalDateTime bookMarkedTime;
 
     @Builder
-    public UserMarkResponse(Long markId, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LinkStatus linkStatus, Boolean isRead, Boolean isMark, List<TagResponse> tagList, LocalDateTime bookMarkedTime) {
+    public UserMarkResponse(Long markId, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, Boolean isRead, Boolean isMark, List<TagResponse> tagList, LocalDateTime bookMarkedTime) {
         this.markId = markId;
         this.linkId = linkId;
         this.url = url;
@@ -33,7 +31,6 @@ public class UserMarkResponse {
         this.description = description;
         this.thumbnail = thumbnail;
         this.bookMarkCount = bookMarkCount;
-        this.linkStatus = linkStatus;
         this.isRead = isRead;
         this.isMark = isMark;
         this.tagList = tagList;
@@ -49,7 +46,6 @@ public class UserMarkResponse {
                 .description(response.getDescription())
                 .thumbnail(response.getThumbnail())
                 .bookMarkCount(response.getBookMarkCount())
-                .linkStatus(response.getLinkStatus())
                 .isRead(isRead)
                 .isMark(isMark)
                 .tagList(tagList)

--- a/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkResponse.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkResponse.java
@@ -3,6 +3,7 @@ package project.linkarchive.backend.bookmark.response;
 import lombok.Builder;
 import lombok.Getter;
 import project.linkarchive.backend.hashtag.response.TagResponse;
+import project.linkarchive.backend.link.enums.LinkStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,13 +18,14 @@ public class UserMarkResponse {
     private String description;
     private String thumbnail;
     private Long bookMarkCount;
-    private LocalDateTime bookMarkedTime;
+    private LinkStatus linkStatus;
     private Boolean isRead;
     private Boolean isMark;
     private List<TagResponse> tagList;
+    private LocalDateTime bookMarkedTime;
 
     @Builder
-    public UserMarkResponse(Long markId, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LocalDateTime bookMarkedTime, Boolean isRead, Boolean isMark, List<TagResponse> tagList) {
+    public UserMarkResponse(Long markId, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LinkStatus linkStatus, Boolean isRead, Boolean isMark, List<TagResponse> tagList, LocalDateTime bookMarkedTime) {
         this.markId = markId;
         this.linkId = linkId;
         this.url = url;
@@ -31,10 +33,11 @@ public class UserMarkResponse {
         this.description = description;
         this.thumbnail = thumbnail;
         this.bookMarkCount = bookMarkCount;
-        this.bookMarkedTime = bookMarkedTime;
+        this.linkStatus = linkStatus;
         this.isRead = isRead;
         this.isMark = isMark;
         this.tagList = tagList;
+        this.bookMarkedTime = bookMarkedTime;
     }
 
     public static UserMarkResponse build(MarkResponse response, Boolean isRead, Boolean isMark, List<TagResponse> tagList) {
@@ -46,10 +49,11 @@ public class UserMarkResponse {
                 .description(response.getDescription())
                 .thumbnail(response.getThumbnail())
                 .bookMarkCount(response.getBookMarkCount())
-                .bookMarkedTime(response.getBookMarkedTime())
+                .linkStatus(response.getLinkStatus())
                 .isRead(isRead)
                 .isMark(isMark)
                 .tagList(tagList)
+                .bookMarkedTime(response.getBookMarkedTime())
                 .build();
     }
 

--- a/src/main/java/project/linkarchive/backend/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/link/repository/LinkRepositoryImpl.java
@@ -35,7 +35,6 @@ public class LinkRepositoryImpl {
                         link.description,
                         link.thumbnail,
                         link.bookMarkCount,
-                        link.linkStatus,
                         link.createdAt,
                         link.updatedAt
                 ))
@@ -62,7 +61,6 @@ public class LinkRepositoryImpl {
                         link.description,
                         link.thumbnail,
                         link.bookMarkCount,
-                        link.linkStatus,
                         link.createdAt,
                         link.updatedAt
                 ))
@@ -92,7 +90,6 @@ public class LinkRepositoryImpl {
                         link.description,
                         link.thumbnail,
                         link.bookMarkCount,
-                        link.linkStatus,
                         link.createdAt,
                         link.updatedAt
                 ))

--- a/src/main/java/project/linkarchive/backend/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/link/repository/LinkRepositoryImpl.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static project.linkarchive.backend.link.domain.QLink.link;
 import static project.linkarchive.backend.link.domain.QLinkHashTag.linkHashTag;
+import static project.linkarchive.backend.link.enums.LinkStatus.ACTIVE;
 import static project.linkarchive.backend.profileImage.domain.QProfileImage.profileImage;
 
 @Repository
@@ -43,6 +44,7 @@ public class LinkRepositoryImpl {
                 .leftJoin(link.linkHashTagList, linkHashTag)
                 .where(
                         link.user.id.eq(userId),
+                        link.linkStatus.eq(ACTIVE),
                         ltUrlId(lastLinkLid),
                         containTag(tag)
                 )
@@ -69,6 +71,7 @@ public class LinkRepositoryImpl {
                 .leftJoin(link.linkHashTagList, linkHashTag)
                 .where(
                         link.user.nickname.eq(nickname),
+                        link.linkStatus.eq(ACTIVE),
                         ltUrlId(lastLinkLid),
                         containTag(tag)
                 )
@@ -92,12 +95,13 @@ public class LinkRepositoryImpl {
                         link.linkStatus,
                         link.createdAt,
                         link.updatedAt
-                        ))
+                ))
                 .from(link)
                 .distinct()
                 .leftJoin(link.user.profileImage, profileImage)
                 .leftJoin(link.linkHashTagList, linkHashTag)
                 .where(
+                        link.linkStatus.eq(ACTIVE),
                         ltUrlId(lastLinkId),
                         containTag(tag)
                 )

--- a/src/main/java/project/linkarchive/backend/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/link/repository/LinkRepositoryImpl.java
@@ -34,7 +34,9 @@ public class LinkRepositoryImpl {
                         link.description,
                         link.thumbnail,
                         link.bookMarkCount,
-                        link.createdAt
+                        link.linkStatus,
+                        link.createdAt,
+                        link.updatedAt
                 ))
                 .from(link)
                 .distinct()
@@ -58,7 +60,9 @@ public class LinkRepositoryImpl {
                         link.description,
                         link.thumbnail,
                         link.bookMarkCount,
-                        link.createdAt
+                        link.linkStatus,
+                        link.createdAt,
+                        link.updatedAt
                 ))
                 .from(link)
                 .distinct()
@@ -84,9 +88,11 @@ public class LinkRepositoryImpl {
                         link.title,
                         link.description,
                         link.thumbnail,
+                        link.bookMarkCount,
+                        link.linkStatus,
                         link.createdAt,
-                        link.bookMarkCount
-                ))
+                        link.updatedAt
+                        ))
                 .from(link)
                 .distinct()
                 .leftJoin(link.user.profileImage, profileImage)

--- a/src/main/java/project/linkarchive/backend/link/response/linkList/LinkResponse.java
+++ b/src/main/java/project/linkarchive/backend/link/response/linkList/LinkResponse.java
@@ -2,7 +2,6 @@ package project.linkarchive.backend.link.response.linkList;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
-import project.linkarchive.backend.link.enums.LinkStatus;
 
 import java.time.LocalDateTime;
 
@@ -15,19 +14,17 @@ public class LinkResponse {
     private String description;
     private String thumbnail;
     private Long bookMarkCount;
-    private LinkStatus linkStatus;
     private LocalDateTime linkCreatedTime;
     private LocalDateTime linkUpdatedTime;
 
     @QueryProjection
-    public LinkResponse(Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LinkStatus linkStatus, LocalDateTime linkCreatedTime, LocalDateTime linkUpdatedTime) {
+    public LinkResponse(Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LocalDateTime linkCreatedTime, LocalDateTime linkUpdatedTime) {
         this.linkId = linkId;
         this.url = url;
         this.title = title;
         this.description = description;
         this.thumbnail = thumbnail;
         this.bookMarkCount = bookMarkCount;
-        this.linkStatus = linkStatus;
         this.linkCreatedTime = linkCreatedTime;
         this.linkUpdatedTime = linkUpdatedTime;
     }

--- a/src/main/java/project/linkarchive/backend/link/response/linkList/LinkResponse.java
+++ b/src/main/java/project/linkarchive/backend/link/response/linkList/LinkResponse.java
@@ -2,6 +2,7 @@ package project.linkarchive.backend.link.response.linkList;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
+import project.linkarchive.backend.link.enums.LinkStatus;
 
 import java.time.LocalDateTime;
 
@@ -14,17 +15,21 @@ public class LinkResponse {
     private String description;
     private String thumbnail;
     private Long bookMarkCount;
+    private LinkStatus linkStatus;
     private LocalDateTime linkCreatedTime;
+    private LocalDateTime linkUpdatedTime;
 
     @QueryProjection
-    public LinkResponse(Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LocalDateTime linkCreatedTime) {
+    public LinkResponse(Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LinkStatus linkStatus, LocalDateTime linkCreatedTime, LocalDateTime linkUpdatedTime) {
         this.linkId = linkId;
         this.url = url;
         this.title = title;
         this.description = description;
         this.thumbnail = thumbnail;
         this.bookMarkCount = bookMarkCount;
+        this.linkStatus = linkStatus;
         this.linkCreatedTime = linkCreatedTime;
+        this.linkUpdatedTime = linkUpdatedTime;
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/link/response/linkList/UserLinkResponse.java
+++ b/src/main/java/project/linkarchive/backend/link/response/linkList/UserLinkResponse.java
@@ -3,7 +3,6 @@ package project.linkarchive.backend.link.response.linkList;
 import lombok.Builder;
 import lombok.Getter;
 import project.linkarchive.backend.hashtag.response.TagResponse;
-import project.linkarchive.backend.link.enums.LinkStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,7 +16,6 @@ public class UserLinkResponse {
     private String description;
     private String thumbnail;
     private Long bookMarkCount;
-    private LinkStatus linkStatus;
     private Boolean isRead;
     private Boolean isMark;
     private List<TagResponse> tagList;
@@ -25,14 +23,13 @@ public class UserLinkResponse {
     private LocalDateTime linkUpdatedTime;
 
     @Builder
-    public UserLinkResponse(Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LinkStatus linkStatus, Boolean isRead, Boolean isMark, List<TagResponse> tagList, LocalDateTime linkCreatedTime, LocalDateTime linkUpdatedTime) {
+    public UserLinkResponse(Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, Boolean isRead, Boolean isMark, List<TagResponse> tagList, LocalDateTime linkCreatedTime, LocalDateTime linkUpdatedTime) {
         this.linkId = linkId;
         this.url = url;
         this.title = title;
         this.description = description;
         this.thumbnail = thumbnail;
         this.bookMarkCount = bookMarkCount;
-        this.linkStatus = linkStatus;
         this.isRead = isRead;
         this.isMark = isMark;
         this.tagList = tagList;
@@ -48,7 +45,6 @@ public class UserLinkResponse {
                 .description(response.getDescription())
                 .thumbnail(response.getThumbnail())
                 .bookMarkCount(response.getBookMarkCount())
-                .linkStatus(response.getLinkStatus())
                 .isRead(isRead)
                 .isMark(isMark)
                 .tagList(tagList)

--- a/src/main/java/project/linkarchive/backend/link/response/linkList/UserLinkResponse.java
+++ b/src/main/java/project/linkarchive/backend/link/response/linkList/UserLinkResponse.java
@@ -3,6 +3,7 @@ package project.linkarchive.backend.link.response.linkList;
 import lombok.Builder;
 import lombok.Getter;
 import project.linkarchive.backend.hashtag.response.TagResponse;
+import project.linkarchive.backend.link.enums.LinkStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,23 +17,27 @@ public class UserLinkResponse {
     private String description;
     private String thumbnail;
     private Long bookMarkCount;
-    private LocalDateTime linkCreatedTime;
+    private LinkStatus linkStatus;
     private Boolean isRead;
     private Boolean isMark;
     private List<TagResponse> tagList;
+    private LocalDateTime linkCreatedTime;
+    private LocalDateTime linkUpdatedTime;
 
     @Builder
-    public UserLinkResponse(Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, Boolean isRead, Boolean isMark, LocalDateTime linkCreatedTime, List<TagResponse> tagList) {
+    public UserLinkResponse(Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LinkStatus linkStatus, Boolean isRead, Boolean isMark, List<TagResponse> tagList, LocalDateTime linkCreatedTime, LocalDateTime linkUpdatedTime) {
         this.linkId = linkId;
         this.url = url;
         this.title = title;
         this.description = description;
         this.thumbnail = thumbnail;
         this.bookMarkCount = bookMarkCount;
-        this.linkCreatedTime = linkCreatedTime;
+        this.linkStatus = linkStatus;
         this.isRead = isRead;
         this.isMark = isMark;
         this.tagList = tagList;
+        this.linkCreatedTime = linkCreatedTime;
+        this.linkUpdatedTime = linkUpdatedTime;
     }
 
     public static UserLinkResponse create(LinkResponse response, Boolean isRead, Boolean isMark, List<TagResponse> tagList) {
@@ -43,10 +48,12 @@ public class UserLinkResponse {
                 .description(response.getDescription())
                 .thumbnail(response.getThumbnail())
                 .bookMarkCount(response.getBookMarkCount())
-                .linkCreatedTime(response.getLinkCreatedTime())
+                .linkStatus(response.getLinkStatus())
                 .isRead(isRead)
                 .isMark(isMark)
                 .tagList(tagList)
+                .linkCreatedTime(response.getLinkCreatedTime())
+                .linkUpdatedTime(response.getLinkUpdatedTime())
                 .build();
     }
 

--- a/src/main/java/project/linkarchive/backend/link/response/linkarchive/ArchiveResponse.java
+++ b/src/main/java/project/linkarchive/backend/link/response/linkarchive/ArchiveResponse.java
@@ -2,6 +2,7 @@ package project.linkarchive.backend.link.response.linkarchive;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
+import project.linkarchive.backend.link.enums.LinkStatus;
 
 import java.time.LocalDateTime;
 
@@ -16,11 +17,13 @@ public class ArchiveResponse {
     private String title;
     private String description;
     private String thumbnail;
-    private LocalDateTime linkCreatedTime;
     private Long bookMarkCount;
+    private LinkStatus linkStatus;
+    private LocalDateTime linkCreatedTime;
+    private LocalDateTime linkUpdatedTime;
 
     @QueryProjection
-    public ArchiveResponse(Long userId, String nickname, String profileImage, Long linkId, String url, String title, String description, String thumbnail, LocalDateTime linkCreatedTime, Long bookMarkCount) {
+    public ArchiveResponse(Long userId, String nickname, String profileImage, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LinkStatus linkStatus, LocalDateTime linkCreatedTime, LocalDateTime linkUpdatedTime) {
         this.userId = userId;
         this.nickname = nickname;
         this.profileImage = profileImage;
@@ -29,8 +32,10 @@ public class ArchiveResponse {
         this.title = title;
         this.description = description;
         this.thumbnail = thumbnail;
-        this.linkCreatedTime = linkCreatedTime;
         this.bookMarkCount = bookMarkCount;
+        this.linkStatus = linkStatus;
+        this.linkCreatedTime = linkCreatedTime;
+        this.linkUpdatedTime = linkUpdatedTime;
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/link/response/linkarchive/ArchiveResponse.java
+++ b/src/main/java/project/linkarchive/backend/link/response/linkarchive/ArchiveResponse.java
@@ -2,7 +2,6 @@ package project.linkarchive.backend.link.response.linkarchive;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
-import project.linkarchive.backend.link.enums.LinkStatus;
 
 import java.time.LocalDateTime;
 
@@ -18,12 +17,11 @@ public class ArchiveResponse {
     private String description;
     private String thumbnail;
     private Long bookMarkCount;
-    private LinkStatus linkStatus;
     private LocalDateTime linkCreatedTime;
     private LocalDateTime linkUpdatedTime;
 
     @QueryProjection
-    public ArchiveResponse(Long userId, String nickname, String profileImage, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LinkStatus linkStatus, LocalDateTime linkCreatedTime, LocalDateTime linkUpdatedTime) {
+    public ArchiveResponse(Long userId, String nickname, String profileImage, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LocalDateTime linkCreatedTime, LocalDateTime linkUpdatedTime) {
         this.userId = userId;
         this.nickname = nickname;
         this.profileImage = profileImage;
@@ -33,7 +31,6 @@ public class ArchiveResponse {
         this.description = description;
         this.thumbnail = thumbnail;
         this.bookMarkCount = bookMarkCount;
-        this.linkStatus = linkStatus;
         this.linkCreatedTime = linkCreatedTime;
         this.linkUpdatedTime = linkUpdatedTime;
     }

--- a/src/main/java/project/linkarchive/backend/link/response/linkarchive/UserArchiveResponse.java
+++ b/src/main/java/project/linkarchive/backend/link/response/linkarchive/UserArchiveResponse.java
@@ -3,7 +3,6 @@ package project.linkarchive.backend.link.response.linkarchive;
 import lombok.Builder;
 import lombok.Getter;
 import project.linkarchive.backend.hashtag.response.TagResponse;
-import project.linkarchive.backend.link.enums.LinkStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,7 +19,6 @@ public class UserArchiveResponse {
     private String description;
     private String thumbnail;
     private Long bookMarkCount;
-    private LinkStatus linkStatus;
     private Boolean isRead;
     private Boolean isMark;
     private List<TagResponse> tagList;
@@ -28,7 +26,7 @@ public class UserArchiveResponse {
     private LocalDateTime linkUpdatedTime;
 
     @Builder
-    public UserArchiveResponse(Long userId, String nickname, String profileImage, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LinkStatus linkStatus, Boolean isRead, Boolean isMark, List<TagResponse> tagList, LocalDateTime linkCreatedTime, LocalDateTime linkUpdatedTime) {
+    public UserArchiveResponse(Long userId, String nickname, String profileImage, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, Boolean isRead, Boolean isMark, List<TagResponse> tagList, LocalDateTime linkCreatedTime, LocalDateTime linkUpdatedTime) {
         this.userId = userId;
         this.nickname = nickname;
         this.profileImage = profileImage;
@@ -38,7 +36,6 @@ public class UserArchiveResponse {
         this.description = description;
         this.thumbnail = thumbnail;
         this.bookMarkCount = bookMarkCount;
-        this.linkStatus = linkStatus;
         this.isRead = isRead;
         this.isMark = isMark;
         this.tagList = tagList;
@@ -57,7 +54,6 @@ public class UserArchiveResponse {
                 .description(response.getDescription())
                 .thumbnail(response.getThumbnail())
                 .bookMarkCount(response.getBookMarkCount())
-                .linkStatus(response.getLinkStatus())
                 .isRead(isRead)
                 .isMark(isMark)
                 .tagList(tagList)

--- a/src/main/java/project/linkarchive/backend/link/response/linkarchive/UserArchiveResponse.java
+++ b/src/main/java/project/linkarchive/backend/link/response/linkarchive/UserArchiveResponse.java
@@ -3,6 +3,7 @@ package project.linkarchive.backend.link.response.linkarchive;
 import lombok.Builder;
 import lombok.Getter;
 import project.linkarchive.backend.hashtag.response.TagResponse;
+import project.linkarchive.backend.link.enums.LinkStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,14 +19,16 @@ public class UserArchiveResponse {
     private String title;
     private String description;
     private String thumbnail;
-    private LocalDateTime linkCreatedTime;
     private Long bookMarkCount;
+    private LinkStatus linkStatus;
     private Boolean isRead;
     private Boolean isMark;
     private List<TagResponse> tagList;
+    private LocalDateTime linkCreatedTime;
+    private LocalDateTime linkUpdatedTime;
 
     @Builder
-    public UserArchiveResponse(Long userId, String nickname, String profileImage, Long linkId, String url, String title, String description, String thumbnail, LocalDateTime linkCreatedTime, Long bookMarkCount, Boolean isRead, Boolean isMark, List<TagResponse> tagList) {
+    public UserArchiveResponse(Long userId, String nickname, String profileImage, Long linkId, String url, String title, String description, String thumbnail, Long bookMarkCount, LinkStatus linkStatus, Boolean isRead, Boolean isMark, List<TagResponse> tagList, LocalDateTime linkCreatedTime, LocalDateTime linkUpdatedTime) {
         this.userId = userId;
         this.nickname = nickname;
         this.profileImage = profileImage;
@@ -34,11 +37,13 @@ public class UserArchiveResponse {
         this.title = title;
         this.description = description;
         this.thumbnail = thumbnail;
-        this.linkCreatedTime = linkCreatedTime;
         this.bookMarkCount = bookMarkCount;
+        this.linkStatus = linkStatus;
         this.isRead = isRead;
         this.isMark = isMark;
         this.tagList = tagList;
+        this.linkCreatedTime = linkCreatedTime;
+        this.linkUpdatedTime = linkUpdatedTime;
     }
 
     public static UserArchiveResponse create(ArchiveResponse response, String preSignedUrl, Boolean isRead, Boolean isMark, List<TagResponse> tagList) {
@@ -51,11 +56,13 @@ public class UserArchiveResponse {
                 .title(response.getTitle())
                 .description(response.getDescription())
                 .thumbnail(response.getThumbnail())
-                .linkCreatedTime(response.getLinkCreatedTime())
                 .bookMarkCount(response.getBookMarkCount())
+                .linkStatus(response.getLinkStatus())
                 .isRead(isRead)
                 .isMark(isMark)
                 .tagList(tagList)
+                .linkCreatedTime(response.getLinkCreatedTime())
+                .linkUpdatedTime(response.getLinkUpdatedTime())
                 .build();
     }
 

--- a/src/test/java/project/linkarchive/backend/util/constant/Constants.java
+++ b/src/test/java/project/linkarchive/backend/util/constant/Constants.java
@@ -1,6 +1,10 @@
 package project.linkarchive.backend.util.constant;
 
+import project.linkarchive.backend.link.enums.LinkStatus;
+
 import java.time.LocalDateTime;
+
+import static project.linkarchive.backend.link.enums.LinkStatus.ACTIVE;
 
 public class Constants {
 
@@ -24,6 +28,7 @@ public class Constants {
     public static final String DESCRIPTION = "Test Description";
     public static final String THUMBNAIL = "Test Thumbnail";
     public static final Long BOOKMARK_COUNT = 10L;
+    public static final LinkStatus LINK_STATUS = ACTIVE;
 
     public static final String META_TITLE = "Test Meta Title";
     public static final String META_DESCRIPTION = "Test Meta Description";
@@ -43,6 +48,7 @@ public class Constants {
 
     public static final String NEW_PROFILE_IMAGE_FILENAME = "New Test ProfileImageFilename";
 
-    public static final LocalDateTime CREATED_AT = LocalDateTime.of(2023, 4, 19, 12, 34, 56);
+    public static final LocalDateTime CREATED_AT = LocalDateTime.of(1995, 4, 19, 12, 34, 56);
+    public static final LocalDateTime UPDATED_AT = LocalDateTime.of(2023, 4, 19, 12, 34, 56);
 
 }

--- a/src/test/java/project/linkarchive/backend/util/setUpData/LinkSetUpData.java
+++ b/src/test/java/project/linkarchive/backend/util/setUpData/LinkSetUpData.java
@@ -75,12 +75,12 @@ public class LinkSetUpData extends SetUpData {
     }
 
     private void setUpArchiveResponse() {
-        archiveResponse = new ArchiveResponse(ID, NICKNAME, PROFILE_IMAGE_FILENAME, ID, URL, TITLE, DESCRIPTION, THUMBNAIL, CREATED_AT, BOOKMARK_COUNT);
+        archiveResponse = new ArchiveResponse(ID, NICKNAME, PROFILE_IMAGE_FILENAME, ID, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, LINK_STATUS, CREATED_AT, UPDATED_AT);
     }
 
     private void setupUserArchiveResponseList() {
         for (int i = 1; i <= 10; i++) {
-            userArchiveResponse = new UserArchiveResponse((long) i, NICKNAME, PROFILE_IMAGE_FILENAME, (long) i, URL, TITLE, DESCRIPTION, THUMBNAIL, CREATED_AT, BOOKMARK_COUNT, IS_READ, IS_MARK, tagResponseList);
+            userArchiveResponse = new UserArchiveResponse((long) i, NICKNAME, PROFILE_IMAGE_FILENAME, (long) i, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, LINK_STATUS, IS_READ, IS_MARK, tagResponseList, CREATED_AT, UPDATED_AT);
             userArchiveResponseList.add(userArchiveResponse);
         }
     }
@@ -90,12 +90,12 @@ public class LinkSetUpData extends SetUpData {
     }
 
     private void setUpLinkResponse() {
-        linkResponse = new LinkResponse(ID, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, CREATED_AT);
+        linkResponse = new LinkResponse(ID, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, LINK_STATUS, CREATED_AT, UPDATED_AT);
     }
 
     private void setUpUserLinkResponseList() {
         for (int i = 1; i <= 10; i++) {
-            getUserLinkResponse = new UserLinkResponse((long) i, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, IS_READ, IS_MARK, CREATED_AT, tagResponseList);
+            getUserLinkResponse = new UserLinkResponse((long) i, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, LINK_STATUS, IS_READ, IS_MARK, tagResponseList, CREATED_AT, UPDATED_AT);
             userLinkResponseList.add(getUserLinkResponse);
         }
     }

--- a/src/test/java/project/linkarchive/backend/util/setUpData/LinkSetUpData.java
+++ b/src/test/java/project/linkarchive/backend/util/setUpData/LinkSetUpData.java
@@ -75,12 +75,12 @@ public class LinkSetUpData extends SetUpData {
     }
 
     private void setUpArchiveResponse() {
-        archiveResponse = new ArchiveResponse(ID, NICKNAME, PROFILE_IMAGE_FILENAME, ID, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, LINK_STATUS, CREATED_AT, UPDATED_AT);
+        archiveResponse = new ArchiveResponse(ID, NICKNAME, PROFILE_IMAGE_FILENAME, ID, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, CREATED_AT, UPDATED_AT);
     }
 
     private void setupUserArchiveResponseList() {
         for (int i = 1; i <= 10; i++) {
-            userArchiveResponse = new UserArchiveResponse((long) i, NICKNAME, PROFILE_IMAGE_FILENAME, (long) i, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, LINK_STATUS, IS_READ, IS_MARK, tagResponseList, CREATED_AT, UPDATED_AT);
+            userArchiveResponse = new UserArchiveResponse((long) i, NICKNAME, PROFILE_IMAGE_FILENAME, (long) i, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, IS_READ, IS_MARK, tagResponseList, CREATED_AT, UPDATED_AT);
             userArchiveResponseList.add(userArchiveResponse);
         }
     }
@@ -90,12 +90,12 @@ public class LinkSetUpData extends SetUpData {
     }
 
     private void setUpLinkResponse() {
-        linkResponse = new LinkResponse(ID, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, LINK_STATUS, CREATED_AT, UPDATED_AT);
+        linkResponse = new LinkResponse(ID, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, CREATED_AT, UPDATED_AT);
     }
 
     private void setUpUserLinkResponseList() {
         for (int i = 1; i <= 10; i++) {
-            getUserLinkResponse = new UserLinkResponse((long) i, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, LINK_STATUS, IS_READ, IS_MARK, tagResponseList, CREATED_AT, UPDATED_AT);
+            getUserLinkResponse = new UserLinkResponse((long) i, URL, TITLE, DESCRIPTION, THUMBNAIL, BOOKMARK_COUNT, IS_READ, IS_MARK, tagResponseList, CREATED_AT, UPDATED_AT);
             userLinkResponseList.add(getUserLinkResponse);
         }
     }


### PR DESCRIPTION
## 개요
link 관련 query 조회 기능 시 response 필드를 추가했어요.

## 📌 관련 이슈
close #171 

## ✨ 과제 내용
- [x] 링크 조회시 Status가 ACTIVE인 상태만 조회 됩니당
- [x] Status 와 update 시간 두 개를 필드에 추가했어요
