### PR TITLE
fix: handling null exceptions when registering tags

### DIFF
--- a/src/main/java/project/linkarchive/backend/hashtag/service/HashTagApiService.java
+++ b/src/main/java/project/linkarchive/backend/hashtag/service/HashTagApiService.java
@@ -3,6 +3,7 @@ package project.linkarchive.backend.hashtag.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.linkarchive.backend.advice.exception.custom.AlreadyExistException;
+import project.linkarchive.backend.advice.exception.custom.LengthRequiredException;
 import project.linkarchive.backend.advice.exception.custom.NotFoundException;
 import project.linkarchive.backend.hashtag.domain.HashTag;
 import project.linkarchive.backend.hashtag.domain.UserHashTag;
@@ -16,8 +17,9 @@ import project.linkarchive.backend.user.repository.UserRepository;
 
 import java.util.List;
 
-import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.ALREADY_EXIST_TAG;
-import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.NOT_FOUND_USER;
+import static project.linkarchive.backend.advice.data.DataConstants.MAXIMUM_TAG_LENGTH;
+import static project.linkarchive.backend.advice.data.DataConstants.MINIMUM_TAG_LENGTH;
+import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.*;
 
 @Service
 @Transactional
@@ -37,6 +39,7 @@ public class HashTagApiService {
 
     public void create(CreateTagRequest request, Long userId) {
         User user = findUserById(userId);
+        validationTagLength(request);
         HashTag hashTag = findAndBuildHashTagByTag(request);
 
         userHashTagRepository.findByHashTagId(hashTag.getId())
@@ -54,6 +57,14 @@ public class HashTagApiService {
     private User findUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
+    }
+
+    private void validationTagLength(CreateTagRequest request) {
+        boolean isTooLong = request.getTag().length() > MAXIMUM_TAG_LENGTH;
+        boolean isTooShort = request.getTag().length() < MINIMUM_TAG_LENGTH;
+        if (isTooLong || isTooShort) {
+            throw new LengthRequiredException(LENGTH_REQUIRED_TAG);
+        }
     }
 
     private HashTag findAndBuildHashTagByTag(CreateTagRequest request) {


### PR DESCRIPTION
## 개요
태그 등록시 null 예외처리가 누락돼서 보완했어요.

## 📌 관련 이슈
close #178 

## ✨ 과제 내용
- [x] 태그 등록시 2글자 이상 8글자 이하만 등록돼요.
