### PR TITLE
fix: id return as null when looking up hashtags

### DIFF
--- a/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkResponse.java
+++ b/src/main/java/project/linkarchive/backend/bookmark/response/UserMarkResponse.java
@@ -37,7 +37,7 @@ public class UserMarkResponse {
         this.bookMarkedTime = bookMarkedTime;
     }
 
-    public static UserMarkResponse build(MarkResponse response, Boolean isRead, Boolean isMark, List<TagResponse> tagList) {
+    public static UserMarkResponse create(MarkResponse response, Boolean isRead, Boolean isMark, List<TagResponse> tagList) {
         return UserMarkResponse.builder()
                 .markId(response.getMarkId())
                 .linkId(response.getLinkId())

--- a/src/main/java/project/linkarchive/backend/hashtag/response/TagResponse.java
+++ b/src/main/java/project/linkarchive/backend/hashtag/response/TagResponse.java
@@ -20,11 +20,7 @@ public class TagResponse {
         this.tagName = tagName;
     }
 
-    public TagResponse(String tagName) {
-        this.tagName = tagName;
-    }
-
-    public static TagResponse build(LinkHashTag linkHashTag) {
+    public static TagResponse create(LinkHashTag linkHashTag) {
         return TagResponse.builder()
                 .tagId(linkHashTag.getHashTag().getId())
                 .tagName(linkHashTag.getHashTag().getTag())

--- a/src/main/java/project/linkarchive/backend/link/service/LinkQueryService.java
+++ b/src/main/java/project/linkarchive/backend/link/service/LinkQueryService.java
@@ -65,7 +65,7 @@ public class LinkQueryService {
                 .map(linkResponse -> {
                     List<LinkHashTag> linkHashTagList = linkHashTagRepository.findByLinkId(linkResponse.getLinkId());
                     List<TagResponse> tagList = linkHashTagList.stream()
-                            .map(TagResponse::build)
+                            .map(TagResponse::create)
                             .collect(Collectors.toList());
 
                     Boolean isRead = isLinkReadRepository.existsByLinkIdAndUserId(linkResponse.getLinkId(), userId);
@@ -90,7 +90,7 @@ public class LinkQueryService {
                 .map(linkResponse -> {
                     List<LinkHashTag> linkHashTagList = linkHashTagRepository.findByLinkId(linkResponse.getLinkId());
                     List<TagResponse> tagList = linkHashTagList.stream()
-                            .map(TagResponse::build)
+                            .map(TagResponse::create)
                             .collect(Collectors.toList());
 
 
@@ -114,7 +114,7 @@ public class LinkQueryService {
                 .map(archiveResponse -> {
                     List<LinkHashTag> linkHashTagList = linkHashTagRepository.findByLinkId(archiveResponse.getLinkId());
                     List<TagResponse> tagList = linkHashTagList.stream()
-                            .map(TagResponse::build)
+                            .map(TagResponse::create)
                             .collect(Collectors.toList());
 
                     Boolean isRead = (loginUserId != null) ? isLinkReadRepository.existsByLinkIdAndUserId(archiveResponse.getLinkId(), loginUserId) : false;
@@ -137,7 +137,7 @@ public class LinkQueryService {
                 .map(trashLinkResponse -> {
                     List<LinkHashTag> linkHashTagList = linkHashTagRepository.findByLinkId(trashLinkResponse.getLinkId());
                     List<TagResponse> tagList = linkHashTagList.stream()
-                            .map(TagResponse::build)
+                            .map(TagResponse::create)
                             .collect(Collectors.toList());
 
                     return TrashLinkListResponse.create(trashLinkResponse, tagList);


### PR DESCRIPTION
## 개요
해시태그 리스트 조회 시 id 가 null 값으로 반환되는 이슈를 해결했어요

## 📌 관련 이슈
close #183 

## ✨ 과제 내용
- [x] 해시태그 조회 시 id 값도 반환되게 수정했어요.
