### PR TITLE
Fix/follow list security

### DIFF
--- a/src/main/java/project/linkarchive/backend/config/SecurityConfig.java
+++ b/src/main/java/project/linkarchive/backend/config/SecurityConfig.java
@@ -29,7 +29,9 @@ public class SecurityConfig implements WebMvcConfigurer {
             "/links/archive",
             "/mark/links/**",
             "/mark/tags/**",
-            "/tags/**"
+            "/tags/**",
+            "/follower-list/{userId}",
+            "/following-list/{userId}"
     };
 
     private final SecurityArgumentResolver securityArgumentResolver;

--- a/src/main/java/project/linkarchive/backend/config/SecurityConfig.java
+++ b/src/main/java/project/linkarchive/backend/config/SecurityConfig.java
@@ -30,8 +30,8 @@ public class SecurityConfig implements WebMvcConfigurer {
             "/mark/links/**",
             "/mark/tags/**",
             "/tags/**",
-            "/follower-list/{userId}",
-            "/following-list/{userId}"
+            "/follower-list/user/{userId}",
+            "/following-list/user/{userId}"
     };
 
     private final SecurityArgumentResolver securityArgumentResolver;

--- a/src/main/java/project/linkarchive/backend/relationship/controller/RelationshipApiController.java
+++ b/src/main/java/project/linkarchive/backend/relationship/controller/RelationshipApiController.java
@@ -23,7 +23,7 @@ public class RelationshipApiController {
         this.relationshipApiService = relationshipApiService;
     }
 
-    @PostMapping("/follow/{followeeId}")
+    @PostMapping("/follow/user/{followeeId}")
     public ResponseEntity<SuccessResponse> followUser(
             @PathVariable(value = "followeeId") Long followeeId,
             AuthInfo authInfo
@@ -32,7 +32,7 @@ public class RelationshipApiController {
         return ResponseEntity.status(CREATED).body(new SuccessResponse(FOLLOW_USER));
     }
 
-    @DeleteMapping("/unfollow/{followeeId}")
+    @DeleteMapping("/unfollow/user/{followeeId}")
     public ResponseEntity<SuccessResponse> unfollowUser(
             @PathVariable(value = "followeeId") Long followeeId,
             AuthInfo authInfo

--- a/src/main/java/project/linkarchive/backend/relationship/controller/RelationshipQueryController.java
+++ b/src/main/java/project/linkarchive/backend/relationship/controller/RelationshipQueryController.java
@@ -1,6 +1,7 @@
 package project.linkarchive.backend.relationship.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,18 +23,18 @@ public class RelationshipQueryController {
     @GetMapping("/follower-list/{userId}")
     public ResponseEntity<FollowListResponse> getFollowerList(
             @PathVariable("userId") Long userId,
-            AuthInfo authInfo
+            @Nullable AuthInfo authInfo
     ) {
-        FollowListResponse followListResponse = relationshipQueryService.getFollowerList(userId, authInfo.getId());
+        FollowListResponse followListResponse = relationshipQueryService.getFollowerList(userId, authInfo);
         return ResponseEntity.ok(followListResponse);
     }
 
     @GetMapping("/following-list/{userId}")
     public ResponseEntity<FollowListResponse> getFollowingList(
             @PathVariable("userId") Long userId,
-            AuthInfo authInfo
+            @Nullable AuthInfo authInfo
     ) {
-        FollowListResponse followListResponse = relationshipQueryService.getFollowingList(userId, authInfo.getId());
+        FollowListResponse followListResponse = relationshipQueryService.getFollowingList(userId, authInfo);
         return ResponseEntity.ok(followListResponse);
     }
 }

--- a/src/main/java/project/linkarchive/backend/relationship/controller/RelationshipQueryController.java
+++ b/src/main/java/project/linkarchive/backend/relationship/controller/RelationshipQueryController.java
@@ -20,7 +20,7 @@ public class RelationshipQueryController {
         this.relationshipQueryService = relationshipQueryService;
     }
 
-    @GetMapping("/follower-list/{userId}")
+    @GetMapping("/follower-list/user/{userId}")
     public ResponseEntity<FollowListResponse> getFollowerList(
             @PathVariable("userId") Long userId,
             @Nullable AuthInfo authInfo
@@ -29,7 +29,7 @@ public class RelationshipQueryController {
         return ResponseEntity.ok(followListResponse);
     }
 
-    @GetMapping("/following-list/{userId}")
+    @GetMapping("/following-list/user/{userId}")
     public ResponseEntity<FollowListResponse> getFollowingList(
             @PathVariable("userId") Long userId,
             @Nullable AuthInfo authInfo


### PR DESCRIPTION
## 개요
팔로잉, 팔로워 리스트를 비로그인 사용자도 조회가능하도록 수정했습니다.
추가로 팔로우, 팔로우 취소, 팔로잉/팔로워 리스트 조회 api 엔드포인트 수정했습니다.

## 📌 관련 이슈
close #209

## ✨ 과제 내용
- [x] 팔로잉, 팔로워 리스트를 비로그인 사용자도 조회가능하도록 수정
- [x] 팔로우, 팔로우 취소, 팔로잉/팔로워 리스트 조회 api 엔드포인트 수정
