### PR TITLE
사용자별 작성한 링크 또는 북마크된 링크에 사용된 해시태그 조회

### DIFF
--- a/src/main/java/project/linkarchive/backend/link/domain/Link.java
+++ b/src/main/java/project/linkarchive/backend/link/domain/Link.java
@@ -61,7 +61,7 @@ public class Link extends TimeEntity {
         this.description = description;
         this.thumbnail = thumbnail;
         this.bookMarkCount = bookMarkCount;
-        this.linkStatus = ACTIVE;
+        this.linkStatus = linkStatus.ACTIVE;
         this.user = user;
     }
 

--- a/src/main/java/project/linkarchive/backend/link/repository/LinkRepository.java
+++ b/src/main/java/project/linkarchive/backend/link/repository/LinkRepository.java
@@ -21,6 +21,7 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
 
     Optional<Link> findByIdAndUserId(Long linkId, Long userId);
 
-    List<Link> findByUserId(Long userId);
+    @Query("SELECT l FROM Link l WHERE l.status = 'ACTIVE' AND l.userId = :userId")
+    List<Link> findByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/project/linkarchive/backend/link/repository/LinkRepository.java
+++ b/src/main/java/project/linkarchive/backend/link/repository/LinkRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import project.linkarchive.backend.link.domain.Link;
+import project.linkarchive.backend.user.domain.User;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,7 +22,7 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
 
     Optional<Link> findByIdAndUserId(Long linkId, Long userId);
 
-    @Query("SELECT l FROM Link l WHERE l.status = 'ACTIVE' AND l.userId = :userId")
-    List<Link> findByUserId(@Param("userId") Long userId);
+    @Query("SELECT l FROM Link l WHERE l.linkStatus = 'ACTIVE' AND l.user = :user")
+    List<Link> findByUser(@Param("user") User user);
 
 }

--- a/src/main/java/project/linkarchive/backend/link/service/LinkApiService.java
+++ b/src/main/java/project/linkarchive/backend/link/service/LinkApiService.java
@@ -5,6 +5,8 @@ import org.springframework.transaction.annotation.Transactional;
 import project.linkarchive.backend.advice.exception.custom.ExceededException;
 import project.linkarchive.backend.advice.exception.custom.LengthRequiredException;
 import project.linkarchive.backend.advice.exception.custom.NotFoundException;
+import project.linkarchive.backend.bookmark.domain.BookMark;
+import project.linkarchive.backend.bookmark.repository.BookMarkRepository;
 import project.linkarchive.backend.hashtag.domain.HashTag;
 import project.linkarchive.backend.hashtag.repository.HashTagRepository;
 import project.linkarchive.backend.hashtag.repository.UserHashTagRepository;
@@ -32,18 +34,20 @@ public class LinkApiService {
     private final LinkHashTagRepository linkHashTagRepository;
     private final UserHashTagRepository userHashTagRepository;
     private final LinkRepository linkRepository;
+    private final BookMarkRepository bookMarkRepository;
 
     public LinkApiService(UserRepository userRepository,
                           HashTagRepository hashTagRepository,
                           LinkHashTagRepository linkHashTagRepository,
                           UserHashTagRepository userHashTagRepository,
-                          LinkRepository linkRepository
-    ) {
+                          LinkRepository linkRepository,
+                          BookMarkRepository bookMarkRepository) {
         this.userRepository = userRepository;
         this.hashTagRepository = hashTagRepository;
         this.linkHashTagRepository = linkHashTagRepository;
         this.userHashTagRepository = userHashTagRepository;
         this.linkRepository = linkRepository;
+        this.bookMarkRepository = bookMarkRepository;
     }
 
     public void create(CreateLinkRequest request, Long userId) {
@@ -64,6 +68,10 @@ public class LinkApiService {
 
         Link link = linkRepository.findByIdAndUserId(linkId, userId)
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_LINK));
+
+        BookMark bookMark = bookMarkRepository.findByLinkIdAndUserId(link.getId(), userId)
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND_BOOKMARK));
+        bookMarkRepository.delete(bookMark);
 
         link.delete();
     }

--- a/src/main/java/project/linkarchive/backend/link/service/LinkQueryService.java
+++ b/src/main/java/project/linkarchive/backend/link/service/LinkQueryService.java
@@ -159,7 +159,7 @@ public class LinkQueryService {
     public TagListResponse getLinkTagList(Long userId) {
         User user = findUserById(userId);
 
-        List<Link> linkList = linkRepository.findByUserId(user.getId());
+        List<Link> linkList = linkRepository.findByUser(user);
         Map<String, Long> tagIdMap = new HashMap<>();
         Map<String, Integer> tagCountMap = new HashMap<>();
 

--- a/src/main/java/project/linkarchive/backend/user/domain/User.java
+++ b/src/main/java/project/linkarchive/backend/user/domain/User.java
@@ -23,7 +23,7 @@ import static project.linkarchive.backend.advice.data.DataConstants.EMPTY;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "`user`", indexes = {@Index(name = "index_nickname", columnList = "nickname", unique = true)})
+@Table(name = "`user`")
 public class User extends TimeEntity {
 
     @Id


### PR DESCRIPTION
## 개요
1. 사용자별 작성한 링크에 사용된 태그 리스트를 조회하는 기능의 로직을 수정했어요.
2. 사용자별 북마크된 링크에 사용된 태그 리스트를 조회하는 기능의 로직을 수정했어요.

## 📌 관련 이슈
링크 삭제 후 북마크 데이터가 남아있어 이슈가 발생했었어요

## ✨ 과제 내용
- [x] 링크 조회 시 태그 리스트를 조회하는 기능에 링크 Status를 검증이 필요해요.
- [x] JPQL 쿼리를 작성해서 해결했어요
- [x] 유저의 닉네임에 인덱싱이 적용되어 있는데 불필요하여 없애줬어요
