### PR TITLE
로그인, 프로필 이미지 수정 시 리스폰스

### DIFF
--- a/src/main/java/project/linkarchive/backend/auth/response/LoginResponse.java
+++ b/src/main/java/project/linkarchive/backend/auth/response/LoginResponse.java
@@ -8,12 +8,14 @@ public class LoginResponse {
 
     private Long userId;
     private String nickname;
+    private String profileImage;
     private String accessToken;
     private String refreshToken;
 
-    public LoginResponse(User user, String accessToken, String refreshToken) {
+    public LoginResponse(User user, String profileImage, String accessToken, String refreshToken) {
         this.userId = user.getId();
         this.nickname = user.getNickname();
+        this.profileImage = profileImage;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
     }

--- a/src/main/java/project/linkarchive/backend/auth/service/OAuthService.java
+++ b/src/main/java/project/linkarchive/backend/auth/service/OAuthService.java
@@ -9,7 +9,6 @@ import project.linkarchive.backend.auth.response.KakaoProfile;
 import project.linkarchive.backend.auth.response.LoginResponse;
 import project.linkarchive.backend.auth.response.OauthToken;
 import project.linkarchive.backend.profileImage.domain.ProfileImage;
-import project.linkarchive.backend.profileImage.repository.ProfileImageRepository;
 import project.linkarchive.backend.user.domain.User;
 import project.linkarchive.backend.user.repository.UserRepository;
 import project.linkarchive.backend.util.JwtUtil;
@@ -25,16 +24,16 @@ public class OAuthService {
 
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
-    private final ProfileImageRepository profileImageRepository;
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Value("${cloud.aws.s3.default-image}")
     private String DEFAULT_IMAGE;
+    @Value("${cloud.aws.s3.url}")
+    private String URL;
 
-    public OAuthService(JwtUtil jwtUtil, UserRepository userRepository, ProfileImageRepository profileImageRepository, RefreshTokenRepository refreshTokenRepository) {
+    public OAuthService(JwtUtil jwtUtil, UserRepository userRepository, RefreshTokenRepository refreshTokenRepository) {
         this.jwtUtil = jwtUtil;
         this.userRepository = userRepository;
-        this.profileImageRepository = profileImageRepository;
         this.refreshTokenRepository = refreshTokenRepository;
     }
 
@@ -62,7 +61,7 @@ public class OAuthService {
                 () -> refreshTokenRepository.save(token)
         );
 
-        return new LoginResponse(findUser, newAccessToken, newRefreshToken);
+        return new LoginResponse(findUser, URL + findUser.getProfileImage().getProfileImageFilename(), newAccessToken, newRefreshToken);
     }
 
     public LoginResponse login(String code, String referer, String userAgent) {
@@ -91,7 +90,7 @@ public class OAuthService {
                         () -> refreshTokenRepository.save(token)
                 );
 
-        return new LoginResponse(findUser, newAccessToken, newRefreshToken);
+        return new LoginResponse(findUser, URL + findUser.getProfileImage().getProfileImageFilename(), newAccessToken, newRefreshToken);
     }
 
     public AccessTokenResponse publishAccessToken(String accessToken, String refreshToken) {

--- a/src/test/java/project/linkarchive/backend/user/service/UserApiServiceTest.java
+++ b/src/test/java/project/linkarchive/backend/user/service/UserApiServiceTest.java
@@ -17,7 +17,6 @@ import project.linkarchive.backend.user.response.UpdateProfileResponse;
 import project.linkarchive.backend.util.setUpData.SetUpMockData;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -106,16 +105,13 @@ class UserApiServiceTest extends SetUpMockData {
                 .thenReturn(Optional.of(user));
         when(s3Uploader.upload(multipartFile))
                 .thenReturn(STORED_FILE_NAME);
-        when(s3Uploader.generatePresignedProfileImageUrl(STORED_FILE_NAME, EXPIRATION_TIME_MINUTE))
-                .thenReturn(new URL(PROFILE_IMAGE_URL));
 
         ProfileImageResponse response = userApiService.updateProfileImage(multipartFile, user.getId());
 
-        assertEquals(PROFILE_IMAGE_URL, response.getProfileImage());
+        assertEquals(null + STORED_FILE_NAME, response.getProfileImage());
 
         verify(userRepository).findById(USER_ID);
         verify(s3Uploader).upload(multipartFile);
-        verify(s3Uploader).generatePresignedProfileImageUrl(STORED_FILE_NAME, EXPIRATION_TIME_MINUTE);
     }
 
     @DisplayName("유저 Api Service - checkIfNicknameIsAvailable")

--- a/src/test/java/project/linkarchive/backend/util/constant/Constants.java
+++ b/src/test/java/project/linkarchive/backend/util/constant/Constants.java
@@ -31,6 +31,7 @@ public class Constants {
     public static final String CONTENT_TYPE = "image/jpg";
     public static final byte[] MULTIPART_FILE_DATA = "image data".getBytes();
     public static final int EXPIRATION_TIME_MINUTE = 3600000;
+    public static final String AWS_S3_URL = "https://linkarchive-profile.s3.ap-northeast-2.amazonaws.com/";
 
     public static final Long REFRESH_TOKEN_ID = 1L;
     public static final String REFRESH_TOKEN = "Test_RefreshToken";


### PR DESCRIPTION
## 개요
로그인, 프로필 이미지 수정 시 리스폰스 변경분이에요

## 📌 관련 이슈
close #240 

## ✨ 과제 내용
- [x] 이제 로그인할 때 프로필 이미지 정보를 같이 응답해줘요
- [x] 프로필 이미지 수정 시 리스폰스에 만료기한 기능 없이 응답해줘요
