### PR TITLE
프로필 이미지 컬럼명 변경

### DIFF
--- a/src/main/java/project/linkarchive/backend/auth/service/KakaoLoginService.java
+++ b/src/main/java/project/linkarchive/backend/auth/service/KakaoLoginService.java
@@ -64,7 +64,7 @@ public class KakaoLoginService {
                         () -> refreshTokenRepository.save(token)
                 );
 
-        return new LoginResponse(findUser, URL + findUser.getProfileImage().getProfileImageFilename(), newAccessToken, newRefreshToken);
+        return new LoginResponse(findUser, URL + findUser.getProfileImage().getFileName(), newAccessToken, newRefreshToken);
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/auth/service/LocalLoginService.java
+++ b/src/main/java/project/linkarchive/backend/auth/service/LocalLoginService.java
@@ -4,9 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import project.linkarchive.backend.auth.domain.RefreshToken;
 import project.linkarchive.backend.auth.repository.RefreshTokenRepository;
-import project.linkarchive.backend.auth.response.KakaoProfile;
 import project.linkarchive.backend.auth.response.LoginResponse;
-import project.linkarchive.backend.auth.response.OauthToken;
 import project.linkarchive.backend.profileImage.domain.ProfileImage;
 import project.linkarchive.backend.user.domain.User;
 import project.linkarchive.backend.user.repository.UserRepository;
@@ -16,7 +14,6 @@ import javax.transaction.Transactional;
 import java.util.Optional;
 
 import static project.linkarchive.backend.advice.data.DataConstants.SOCIAL_LOGIN;
-import static project.linkarchive.backend.auth.AuthProvider.LOCAL;
 
 @Service
 @Transactional
@@ -58,7 +55,7 @@ public class LocalLoginService {
                 () -> refreshTokenRepository.save(token)
         );
 
-        return new LoginResponse(findUser, URL + findUser.getProfileImage().getProfileImageFilename(), newAccessToken, newRefreshToken);
+        return new LoginResponse(findUser, URL + findUser.getProfileImage().getFileName(), newAccessToken, newRefreshToken);
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/link/repository/LinkRepositoryImpl.java
+++ b/src/main/java/project/linkarchive/backend/link/repository/LinkRepositoryImpl.java
@@ -86,7 +86,7 @@ public class LinkRepositoryImpl {
                 .select(new QArchiveResponse(
                         link.user.id,
                         link.user.nickname,
-                        link.user.profileImage.profileImageFilename,
+                        link.user.profileImage.fileName,
                         link.id,
                         link.url,
                         link.title,

--- a/src/main/java/project/linkarchive/backend/profileImage/domain/ProfileImage.java
+++ b/src/main/java/project/linkarchive/backend/profileImage/domain/ProfileImage.java
@@ -19,25 +19,25 @@ public class ProfileImage extends TimeEntity {
     @Column(name = "profile_image_id")
     private Long id;
 
-    private String profileImageFilename;
+    private String fileName;
 
     @OneToOne(mappedBy = "profileImage", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private User user;
 
     @Builder
-    public ProfileImage(Long id, String profileImageFilename) {
+    public ProfileImage(Long id, String fileName) {
         this.id = id;
-        this.profileImageFilename = profileImageFilename;
+        this.fileName = fileName;
     }
 
-    public static ProfileImage create(String profileImageFilename) {
+    public static ProfileImage create(String fileName) {
         return ProfileImage.builder()
-                .profileImageFilename(profileImageFilename)
+                .fileName(fileName)
                 .build();
     }
 
     public void updateProfileImage(String profileImage) {
-        this.profileImageFilename = profileImage;
+        this.fileName = profileImage;
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/relationship/service/RelationshipQueryService.java
+++ b/src/main/java/project/linkarchive/backend/relationship/service/RelationshipQueryService.java
@@ -64,7 +64,7 @@ public class RelationshipQueryService {
 
         List<FollowResponse> followResponses = new ArrayList<>();
         followList.forEach(user -> {
-            String profileImageUrl = userQueryService.generateProfileImageUrl(user.getProfileImage().getProfileImageFilename());
+            String profileImageUrl = userQueryService.generateProfileImageUrl(user.getProfileImage().getFileName());
 
             Boolean isFollow = loginUserId != null && isFollowing(user.getId(), loginUserId);
 

--- a/src/main/java/project/linkarchive/backend/user/service/UserApiService.java
+++ b/src/main/java/project/linkarchive/backend/user/service/UserApiService.java
@@ -71,14 +71,14 @@ public class UserApiService {
 
         String storedFileName = s3Uploader.upload(image);
 
-        if (!user.getProfileImage().getProfileImageFilename().equals(DEFAULT_IMAGE)) {
-            s3Uploader.deleteFile(user.getProfileImage().getProfileImageFilename());
+        if (!user.getProfileImage().getFileName().equals(DEFAULT_IMAGE)) {
+            s3Uploader.deleteFile(user.getProfileImage().getFileName());
         }
 
         ProfileImage profileImage = user.getProfileImage();
         profileImage.updateProfileImage(storedFileName);
 
-        return new ProfileImageResponse(URL + profileImage.getProfileImageFilename());
+        return new ProfileImageResponse(URL + profileImage.getFileName());
     }
 
     public ProfileImageResponse defaultProfileImage(Long userId) {
@@ -87,7 +87,7 @@ public class UserApiService {
         ProfileImage profileImage = user.getProfileImage();
         profileImage.updateProfileImage(DEFAULT_IMAGE);
 
-        return new ProfileImageResponse(URL + profileImage.getProfileImageFilename());
+        return new ProfileImageResponse(URL + profileImage.getFileName());
     }
 
     public void checkIfNicknameIsAvailable(String nickname) {

--- a/src/main/java/project/linkarchive/backend/user/service/UserQueryService.java
+++ b/src/main/java/project/linkarchive/backend/user/service/UserQueryService.java
@@ -30,14 +30,14 @@ public class UserQueryService {
 
     public MyProfileResponse getMyProfile(Long userId) {
         User user = getUserById(userId);
-        String profileImageUrl = generateProfileImageUrl(user.getProfileImage().getProfileImageFilename());
+        String profileImageUrl = generateProfileImageUrl(user.getProfileImage().getFileName());
 
         return new MyProfileResponse(user, profileImageUrl);
     }
 
     public UserProfileResponse getUserProfile(Long userId, AuthInfo authInfo) {
         User user = getUserById(userId);
-        String profileImageUrl = generateProfileImageUrl(user.getProfileImage().getProfileImageFilename());
+        String profileImageUrl = generateProfileImageUrl(user.getProfileImage().getFileName());
 
         Long loginUserId = authInfo != null ? authInfo.getId() : null;
         if (loginUserId == null) {

--- a/src/test/java/project/linkarchive/backend/profileImage/domain/ProfileImageTest.java
+++ b/src/test/java/project/linkarchive/backend/profileImage/domain/ProfileImageTest.java
@@ -25,7 +25,7 @@ class ProfileImageTest extends SetUpMockData {
     @DisplayName("프로필 이미지 getProfileImageFileName - Domain")
     @Test
     void testGetProfileImageFilename() {
-        assertEquals(PROFILE_IMAGE_FILENAME, profileImage.getProfileImageFilename());
+        assertEquals(PROFILE_IMAGE_FILENAME, profileImage.getFileName());
     }
 
     @DisplayName("프로필 이미지 생성자 - Domain")
@@ -34,17 +34,17 @@ class ProfileImageTest extends SetUpMockData {
         profileImage = new ProfileImage(PROFILE_IMAGE_ID, PROFILE_IMAGE_FILENAME);
 
         assertEquals(PROFILE_IMAGE_ID, profileImage.getId());
-        assertEquals(PROFILE_IMAGE_FILENAME, profileImage.getProfileImageFilename());
+        assertEquals(PROFILE_IMAGE_FILENAME, profileImage.getFileName());
     }
 
     @DisplayName("프로필 이미지 Builder 패턴 - Domain")
     @Test
     void testBuilder() {
         profileImage = ProfileImage.builder()
-                .profileImageFilename(PROFILE_IMAGE_FILENAME)
+                .fileName(PROFILE_IMAGE_FILENAME)
                 .build();
 
-        assertEquals(PROFILE_IMAGE_FILENAME, profileImage.getProfileImageFilename());
+        assertEquals(PROFILE_IMAGE_FILENAME, profileImage.getFileName());
     }
 
     @DisplayName("프로필 이미지 create 메서드 - Domain")
@@ -52,16 +52,16 @@ class ProfileImageTest extends SetUpMockData {
     void testCreate() {
         profileImage = ProfileImage.create(PROFILE_IMAGE_FILENAME);
 
-        assertEquals(PROFILE_IMAGE_FILENAME, profileImage.getProfileImageFilename());
+        assertEquals(PROFILE_IMAGE_FILENAME, profileImage.getFileName());
     }
 
     @DisplayName("프로필 이미지 UpdateProfileImage - Domain")
     @Test
     void testUpdateProfileImage() {
-        String oldProfileImageFilename = profileImage.getProfileImageFilename();
+        String oldProfileImageFilename = profileImage.getFileName();
 
         profileImage.updateProfileImage(NEW_PROFILE_IMAGE_FILENAME);
-        String newProfileImageFileName = profileImage.getProfileImageFilename();
+        String newProfileImageFileName = profileImage.getFileName();
 
         assertNotEquals(oldProfileImageFilename, newProfileImageFileName);
         assertEquals(NEW_PROFILE_IMAGE_FILENAME, newProfileImageFileName);

--- a/src/test/java/project/linkarchive/backend/util/setUpData/SetUpMockData.java
+++ b/src/test/java/project/linkarchive/backend/util/setUpData/SetUpMockData.java
@@ -1,7 +1,6 @@
 package project.linkarchive.backend.util.setUpData;
 
 import org.springframework.mock.web.MockMultipartFile;
-import project.linkarchive.backend.auth.AuthProvider;
 import project.linkarchive.backend.auth.response.KakaoAccount;
 import project.linkarchive.backend.auth.response.KakaoProfile;
 import project.linkarchive.backend.link.domain.Link;
@@ -50,7 +49,7 @@ public class SetUpMockData extends MockDataGenerator {
     protected void setUpProfileImage() {
         profileImage = ProfileImage.builder()
                 .id(PROFILE_IMAGE_ID)
-                .profileImageFilename(PROFILE_IMAGE_FILENAME)
+                .fileName(PROFILE_IMAGE_FILENAME)
                 .build();
     }
 


### PR DESCRIPTION
## 개요
프로필 이미지 데이터베이스의 프로필 이미지 파일 네임 컬럼명을 변경했어요

## 📌 관련 이슈
close #230 

## ✨ 과제 내용
- [x] 단순 프로필 이미지 파일 네임의 컬럼명을 변경했어요
- [x] profileImageFileName -> fileName 으로 변경했어요
- [x] ex) user.getProfileImage.profileImageFileName -> user.getProfileImage.fileName
- [x] 프로필이미지 네임이 중복으로 들어가서 어색함이보여서 변경해줬어요
