### PR TITLE
Fix/security issue

### DIFF
--- a/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
+++ b/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
@@ -7,6 +7,7 @@ public enum ExceptionCodeConst {
 
     BAD_REQUEST_TOKEN(400, "BAD_REQUEST_TOKEN", "헤더에 토큰이 없습니다."),
     ACCESS_TOKEN_STILL_VALID(400, "ACCESS_TOKEN_STILL_VALID", "엑세스 토큰의 만료시간이 남아있습니다."),
+
     INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다. 로그인이 필요합니다."),
     TOKEN_TYPE_ERROR(401, "TOKEN_TYPE_ERROR", "Bearer 타입의 토큰이 아닙니다."),
     EXPIRED_TOKEN(401, "EXPIRED_TOKEN", "만료된 토큰입니다."),
@@ -16,6 +17,7 @@ public enum ExceptionCodeConst {
     INVALID_LINK_ACCESS(401, "INVALID_LINK_ACCESS", "이 링크를 복구할 권한이 없습니다."),
 
     FORBIDDEN_ACCESS(403, "FORBIDDEN_ACCESS", "권한이 없습니다."),
+
 
     NOT_FOUND_USER(404, "NOT_FOUND_USER", "유저가 존재하지 않습니다."),
     NOT_FOUND_TOKEN(404, "NOT_FOUND_TOKEN", "토큰이 존재하지 않습니다."),

--- a/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
+++ b/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
@@ -6,9 +6,8 @@ import lombok.Getter;
 public enum ExceptionCodeConst {
 
     BAD_REQUEST_TOKEN(400, "BAD_REQUEST_TOKEN", "헤더에 토큰이 없습니다."),
-    ACCESS_TOKEN_STILL_VALID(400, "ACCESS_TOKEN_STILL_VALID", "엑세스 토큰의 만료시간이 남아있습니다."),
 
-    INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다. 로그인이 필요합니다."),
+    INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     TOKEN_TYPE_ERROR(401, "TOKEN_TYPE_ERROR", "Bearer 타입의 토큰이 아닙니다."),
     EXPIRED_TOKEN(401, "EXPIRED_TOKEN", "만료된 토큰입니다."),
     INVALID_AUTHORIZATION_CODE(401, "INVALID_AUTHORIZATION_CODE", "잘못된 인가코드입니다."),
@@ -20,7 +19,7 @@ public enum ExceptionCodeConst {
 
 
     NOT_FOUND_USER(404, "NOT_FOUND_USER", "유저가 존재하지 않습니다."),
-    NOT_FOUND_TOKEN(404, "NOT_FOUND_TOKEN", "토큰이 존재하지 않습니다."),
+    NOT_FOUND_TOKEN(404, "NOT_FOUND_TOKEN", "twincle에서 발급한 토큰이 아닙니다."),
     NOT_FOUND_PROFILE_IMAGE(404, "NOT_FOUND_PROFILE_IMAGE", "프로필 이미지가 존재하지 않습니다."),
     NOT_FOUND_LINK(404, "NOT_FOUND_URL", "존재하지 않는 Link 입니다."),
     NOT_FOUND_BOOKMARK(404, "NOT_FOUND_BOOKMARK", "존재하지 않는 북마크입니다."),

--- a/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
+++ b/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 @Getter
 public enum ExceptionCodeConst {
 
-    BAD_REQUEST_TOKEN(400, "BAD_REQUEST_TOKEN", "헤더에 토큰이 없습니다."),
+    NOT_TOKEN_IN_HEADER(400, "NOT_TOKEN_IN_HEADER", "헤더에 토큰이 없습니다."),
 
     INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
-    TOKEN_TYPE_ERROR(401, "TOKEN_TYPE_ERROR", "Bearer 타입의 토큰이 아닙니다."),
+    IS_NOT_BEARER(401, "IS_NOT_BEARER", "Bearer 타입의 토큰이 아닙니다."),
     EXPIRED_TOKEN(401, "EXPIRED_TOKEN", "만료된 토큰입니다."),
     INVALID_AUTHORIZATION_CODE(401, "INVALID_AUTHORIZATION_CODE", "잘못된 인가코드입니다."),
     INVALID_BAD_WORD(401, "INVALID_BAD_WORD", "욕설은 허용하지 않습니다."),
@@ -19,7 +19,7 @@ public enum ExceptionCodeConst {
 
 
     NOT_FOUND_USER(404, "NOT_FOUND_USER", "유저가 존재하지 않습니다."),
-    NOT_FOUND_TOKEN(404, "NOT_FOUND_TOKEN", "twincle에서 발급한 토큰이 아닙니다."),
+    NOT_PUBLISHED_BY_TWINCLE(404, "NOT_PUBLISHED_BY_TWINCLE", "twincle에서 발급한 토큰이 아닙니다."),
     NOT_FOUND_PROFILE_IMAGE(404, "NOT_FOUND_PROFILE_IMAGE", "프로필 이미지가 존재하지 않습니다."),
     NOT_FOUND_LINK(404, "NOT_FOUND_URL", "존재하지 않는 Link 입니다."),
     NOT_FOUND_BOOKMARK(404, "NOT_FOUND_BOOKMARK", "존재하지 않는 북마크입니다."),

--- a/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
+++ b/src/main/java/project/linkarchive/backend/advice/exception/ExceptionCodeConst.java
@@ -5,10 +5,11 @@ import lombok.Getter;
 @Getter
 public enum ExceptionCodeConst {
 
-    BAD_REQUEST_TOKEN(400, "BAD_REQUEST_TOKEN", "잘못된 토큰 요청입니다."),
+    BAD_REQUEST_TOKEN(400, "BAD_REQUEST_TOKEN", "헤더에 토큰이 없습니다."),
     ACCESS_TOKEN_STILL_VALID(400, "ACCESS_TOKEN_STILL_VALID", "엑세스 토큰의 만료시간이 남아있습니다."),
-
     INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다. 로그인이 필요합니다."),
+    TOKEN_TYPE_ERROR(401, "TOKEN_TYPE_ERROR", "Bearer 타입의 토큰이 아닙니다."),
+    EXPIRED_TOKEN(401, "EXPIRED_TOKEN", "만료된 토큰입니다."),
     INVALID_AUTHORIZATION_CODE(401, "INVALID_AUTHORIZATION_CODE", "잘못된 인가코드입니다."),
     INVALID_BAD_WORD(401, "INVALID_BAD_WORD", "욕설은 허용하지 않습니다."),
     INVALID_TRASH_LINK(401, "INVALID_TRASH_LINK", "삭제된 링크가 아닙니다"),

--- a/src/main/java/project/linkarchive/backend/auth/controller/OAuthController.java
+++ b/src/main/java/project/linkarchive/backend/auth/controller/OAuthController.java
@@ -42,9 +42,10 @@ public class OAuthController {
 
     @PostMapping("/publish/access-token")
     public AccessTokenResponse publishAccessToken(
-            @RequestBody RefreshTokenRequest accessTokenRequest
+            @RequestBody RefreshTokenRequest accessTokenRequest,
+            @RequestHeader("User-Agent") String userAgent
     ) {
-        return oauthService.publishAccessToken(accessTokenRequest.getRefreshToken());
+        return oauthService.publishAccessToken(accessTokenRequest.getRefreshToken(), userAgent);
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/auth/controller/OAuthController.java
+++ b/src/main/java/project/linkarchive/backend/auth/controller/OAuthController.java
@@ -2,7 +2,7 @@ package project.linkarchive.backend.auth.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import project.linkarchive.backend.auth.request.AccessTokenRequest;
+import project.linkarchive.backend.auth.request.RefreshTokenRequest;
 import project.linkarchive.backend.auth.response.AccessTokenResponse;
 import project.linkarchive.backend.auth.response.LoginResponse;
 import project.linkarchive.backend.auth.service.LocalLoginService;
@@ -42,10 +42,9 @@ public class OAuthController {
 
     @PostMapping("/publish/access-token")
     public AccessTokenResponse publishAccessToken(
-            @RequestHeader("Authorization") String refreshToken,
-            @RequestBody AccessTokenRequest accessTokenRequest
+            @RequestBody RefreshTokenRequest accessTokenRequest
     ) {
-        return oauthService.publishAccessToken(accessTokenRequest.getAccessToken(), refreshToken);
+        return oauthService.publishAccessToken(accessTokenRequest.getRefreshToken());
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/auth/controller/OAuthController.java
+++ b/src/main/java/project/linkarchive/backend/auth/controller/OAuthController.java
@@ -42,10 +42,10 @@ public class OAuthController {
 
     @PostMapping("/publish/access-token")
     public AccessTokenResponse publishAccessToken(
-            @RequestBody RefreshTokenRequest accessTokenRequest,
+            @RequestBody RefreshTokenRequest request,
             @RequestHeader("User-Agent") String userAgent
     ) {
-        return oauthService.publishAccessToken(accessTokenRequest.getRefreshToken(), userAgent);
+        return oauthService.publishAccessToken(request.getRefreshToken(), userAgent);
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/project/linkarchive/backend/auth/repository/RefreshTokenRepository.java
@@ -9,7 +9,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     Optional<RefreshToken> findByRefreshTokenAndAgent(String refreshToken, String agent);
 
-
     Optional<RefreshToken> findByUserIdAndAgent(Long userId, String agent);
 
 }

--- a/src/main/java/project/linkarchive/backend/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/project/linkarchive/backend/auth/repository/RefreshTokenRepository.java
@@ -7,7 +7,8 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
-    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+    Optional<RefreshToken> findByRefreshTokenAndAgent(String refreshToken, String agent);
+
 
     Optional<RefreshToken> findByUserIdAndAgent(Long userId, String agent);
 

--- a/src/main/java/project/linkarchive/backend/auth/request/RefreshTokenRequest.java
+++ b/src/main/java/project/linkarchive/backend/auth/request/RefreshTokenRequest.java
@@ -6,12 +6,12 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AccessTokenRequest {
+public class RefreshTokenRequest {
 
-    private String accessToken;
+    private String refreshToken;
 
-    public AccessTokenRequest(String accessToken) {
-        this.accessToken = accessToken;
+    public RefreshTokenRequest(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/auth/response/AccessTokenResponse.java
+++ b/src/main/java/project/linkarchive/backend/auth/response/AccessTokenResponse.java
@@ -6,11 +6,9 @@ import lombok.Getter;
 public class AccessTokenResponse {
 
     String accessToken;
-    String refreshToken;
 
-    public AccessTokenResponse(String accessToken, String refreshToken) {
+    public AccessTokenResponse(String accessToken) {
         this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/auth/response/AccessTokenResponse.java
+++ b/src/main/java/project/linkarchive/backend/auth/response/AccessTokenResponse.java
@@ -6,9 +6,11 @@ import lombok.Getter;
 public class AccessTokenResponse {
 
     String accessToken;
+    String refreshToken;
 
-    public AccessTokenResponse(String accessToken) {
+    public AccessTokenResponse(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/auth/service/OauthService.java
+++ b/src/main/java/project/linkarchive/backend/auth/service/OauthService.java
@@ -29,8 +29,8 @@ public class OauthService {
         return null;
     }
 
-    public AccessTokenResponse publishAccessToken(String refreshToken) {
-        return jwtUtil.publishAccessToken(refreshToken);
+    public AccessTokenResponse publishAccessToken(String refreshToken, String userAgent) {
+        return jwtUtil.publishAccessToken(refreshToken, userAgent);
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/auth/service/OauthService.java
+++ b/src/main/java/project/linkarchive/backend/auth/service/OauthService.java
@@ -29,8 +29,8 @@ public class OauthService {
         return null;
     }
 
-    public AccessTokenResponse publishAccessToken(String accessToken, String refreshToken) {
-        return jwtUtil.publishAccessToken(accessToken, refreshToken);
+    public AccessTokenResponse publishAccessToken(String refreshToken) {
+        return jwtUtil.publishAccessToken(refreshToken);
     }
 
 }

--- a/src/main/java/project/linkarchive/backend/config/SecurityConfig.java
+++ b/src/main/java/project/linkarchive/backend/config/SecurityConfig.java
@@ -9,9 +9,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import project.linkarchive.backend.security.SecurityArgumentResolver;
-import project.linkarchive.backend.security.SecurityExceptionHandler;
-import project.linkarchive.backend.security.TokenAuthenticationFilter;
+import project.linkarchive.backend.security.*;
 import project.linkarchive.backend.util.JwtUtil;
 
 import java.util.List;

--- a/src/main/java/project/linkarchive/backend/config/SecurityConfig.java
+++ b/src/main/java/project/linkarchive/backend/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig implements WebMvcConfigurer {
             "/tags/**",
             "/follower-list/user/{userId}",
             "/following-list/user/{userId}",
-            "tags/archive"
+            "tags/archive",
+            "/publish/access-token"
     };
 
     private final SecurityArgumentResolver securityArgumentResolver;

--- a/src/main/java/project/linkarchive/backend/security/SecurityExceptionHandler.java
+++ b/src/main/java/project/linkarchive/backend/security/SecurityExceptionHandler.java
@@ -34,12 +34,12 @@ public class SecurityExceptionHandler implements AuthenticationEntryPoint, Acces
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         ExceptionCodeConst exception = (ExceptionCodeConst) request.getAttribute("exception");
 
-        if (exception.equals(BAD_REQUEST_TOKEN)) {
-            handler.resolveException(request, response, null, new InvalidException(BAD_REQUEST_TOKEN));
+        if (exception.equals(NOT_TOKEN_IN_HEADER)) {
+            handler.resolveException(request, response, null, new InvalidException(NOT_TOKEN_IN_HEADER));
         }
 
-        if (exception.equals(TOKEN_TYPE_ERROR)) {
-            handler.resolveException(request, response, null, new InvalidException(TOKEN_TYPE_ERROR));
+        if (exception.equals(IS_NOT_BEARER)) {
+            handler.resolveException(request, response, null, new InvalidException(IS_NOT_BEARER));
         }
 
         if (exception.equals(INVALID_TOKEN)) {

--- a/src/main/java/project/linkarchive/backend/security/SecurityExceptionHandler.java
+++ b/src/main/java/project/linkarchive/backend/security/SecurityExceptionHandler.java
@@ -38,14 +38,13 @@ public class SecurityExceptionHandler implements AuthenticationEntryPoint, Acces
             handler.resolveException(request, response, null, new InvalidException(BAD_REQUEST_TOKEN));
         }
 
+        if (exception.equals(TOKEN_TYPE_ERROR)) {
+            handler.resolveException(request, response, null, new InvalidException(TOKEN_TYPE_ERROR));
+        }
+
         if (exception.equals(INVALID_TOKEN)) {
             handler.resolveException(request, response, null, new UnauthorizedException(INVALID_TOKEN));
         }
-
-        if (exception.equals(NOT_FOUND_USER)) {
-            handler.resolveException(request, response, null, new InvalidException(NOT_FOUND_USER));
-        }
-
     }
 
     @Override

--- a/src/main/java/project/linkarchive/backend/security/TokenAuthenticationFilter.java
+++ b/src/main/java/project/linkarchive/backend/security/TokenAuthenticationFilter.java
@@ -1,8 +1,5 @@
 package project.linkarchive.backend.security;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -35,7 +32,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         String tokenHeader = request.getHeader("Authorization");
 
         if (tokenHeader == null) {
-            request.setAttribute("exception", BAD_REQUEST_TOKEN);
+            request.setAttribute("exception", NOT_TOKEN_IN_HEADER);
             filterChain.doFilter(request, response);
             return;
         }
@@ -43,7 +40,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         String[] tokenData = tokenHeader.split(" ");
 
         if (!tokenData[TOKEN_TYPE_INDEX].equalsIgnoreCase(BEARER)) {
-            request.setAttribute("exception", TOKEN_TYPE_ERROR);
+            request.setAttribute("exception", IS_NOT_BEARER);
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/project/linkarchive/backend/security/TokenAuthenticationFilter.java
+++ b/src/main/java/project/linkarchive/backend/security/TokenAuthenticationFilter.java
@@ -1,5 +1,9 @@
 package project.linkarchive.backend.security;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -13,9 +17,9 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static project.linkarchive.backend.advice.data.DataConstants.*;
-import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.BAD_REQUEST_TOKEN;
-import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.INVALID_TOKEN;
+import static project.linkarchive.backend.advice.exception.ExceptionCodeConst.*;
 
+@Slf4j
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
@@ -38,14 +42,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
         String[] tokenData = tokenHeader.split(" ");
 
-        if (tokenData.length != TOKEN_LENGTH) {
-            request.setAttribute("exception", INVALID_TOKEN);
-            filterChain.doFilter(request, response);
-            return;
-        }
-
         if (!tokenData[TOKEN_TYPE_INDEX].equalsIgnoreCase(BEARER)) {
-            request.setAttribute("exception", INVALID_TOKEN);
+            request.setAttribute("exception", TOKEN_TYPE_ERROR);
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/project/linkarchive/backend/util/JwtUtil.java
+++ b/src/main/java/project/linkarchive/backend/util/JwtUtil.java
@@ -184,7 +184,6 @@ public class JwtUtil {
     }
 
     public AccessTokenResponse publishAccessToken(String refreshToken) {
-
         String getRefreshToken = getTokenWithoutBearer(refreshToken);
         RefreshToken savedRefreshToken;
 
@@ -196,12 +195,8 @@ public class JwtUtil {
                     .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
 
             String newAccessToken = createAccessToken(user);
-            String newRefreshToken = createRefreshToken(user);
 
-            RefreshToken renewalRefreshToken = RefreshToken.create(newRefreshToken, savedRefreshToken.getAgent(), user);
-            savedRefreshToken.updateRefreshToken(renewalRefreshToken);
-
-            return new AccessTokenResponse(newAccessToken, newRefreshToken);
+            return new AccessTokenResponse(newAccessToken);
 
         } else {
             throw new UnauthorizedException(INVALID_TOKEN);

--- a/src/main/java/project/linkarchive/backend/util/JwtUtil.java
+++ b/src/main/java/project/linkarchive/backend/util/JwtUtil.java
@@ -187,12 +187,10 @@ public class JwtUtil {
         String getRefreshToken = getTokenWithoutBearer(refreshToken);
         RefreshToken savedRefreshToken;
 
-        savedRefreshToken = refreshTokenRepository.findByRefreshTokenAndAgent(getRefreshToken, userAgent)
-                .orElseThrow(() -> new UnauthorizedException(NOT_FOUND_TOKEN));
+        savedRefreshToken = getRefreshToken(userAgent, getRefreshToken);
 
         if (isValidatedToken(getRefreshToken)) {
-            User user = userRepository.findById(savedRefreshToken.getUser().getId())
-                    .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
+            User user = getUser(savedRefreshToken);
 
             String newAccessToken = createAccessToken(user);
 
@@ -202,6 +200,16 @@ public class JwtUtil {
             throw new UnauthorizedException(INVALID_TOKEN);
         }
 
+    }
+
+    private User getUser(RefreshToken savedRefreshToken) {
+        return userRepository.findById(savedRefreshToken.getUser().getId())
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
+    }
+
+    private RefreshToken getRefreshToken(String userAgent, String getRefreshToken) {
+        return refreshTokenRepository.findByRefreshTokenAndAgent(getRefreshToken, userAgent)
+                .orElseThrow(() -> new UnauthorizedException(NOT_PUBLISHED_BY_TWINCLE));
     }
 
     public boolean isValidatedToken(String token) {
@@ -223,5 +231,6 @@ public class JwtUtil {
 
         return tokenWithoutBearer;
     }
+
 
 }

--- a/src/main/java/project/linkarchive/backend/util/JwtUtil.java
+++ b/src/main/java/project/linkarchive/backend/util/JwtUtil.java
@@ -183,11 +183,11 @@ public class JwtUtil {
         return userId;
     }
 
-    public AccessTokenResponse publishAccessToken(String refreshToken) {
+    public AccessTokenResponse publishAccessToken(String refreshToken, String userAgent) {
         String getRefreshToken = getTokenWithoutBearer(refreshToken);
         RefreshToken savedRefreshToken;
 
-        savedRefreshToken = refreshTokenRepository.findByRefreshToken(getRefreshToken)
+        savedRefreshToken = refreshTokenRepository.findByRefreshTokenAndAgent(getRefreshToken, userAgent)
                 .orElseThrow(() -> new UnauthorizedException(NOT_FOUND_TOKEN));
 
         if (isValidatedToken(getRefreshToken)) {


### PR DESCRIPTION
## 개요
엑세스 토큰 재발급 api 조회 시 발생하는 리프레시 토큰 관련 에러를 로직 변경으로 해결했습니다.
security 필터에서 발생하는 예외 처리 메시지를 명시적으로 수정했습니다.


## 📌 관련 이슈


## ✨ 과제 내용
- [ ] 엑세스 토큰 재발급하는 방법을 수정했습니다.
- [ ] security 필터에서 발생하는 예외 처리 메시지를 명시적으로 수정했습니다.
